### PR TITLE
Allow full sync on datadir

### DIFF
--- a/scripts/start-op-geth.sh
+++ b/scripts/start-op-geth.sh
@@ -58,7 +58,6 @@ exec geth \
   --rollup.disabletxpoolgossip=true \
   --port="${PORT__OP_GETH_P2P:-39393}" \
   --discovery.port="${PORT__OP_GETH_P2P:-39393}" \
-  --db.engine=pebble \
   --snapshot=true \
   --verbosity=3 \
   $EXTENDED_ARG $@


### PR DESCRIPTION
This allows for use of a pre-exising datadir with leveldb.

If the db.engine flag is explicitly set then only the chose db engine
can be used. If the db.engine flag is unset then it will first use the db
engine found in the datadir, and if there is no datadir it will default to pebble.