### PR TITLE
Support custom ipc path

### DIFF
--- a/alfajores.env
+++ b/alfajores.env
@@ -49,6 +49,12 @@ IS_CUSTOM_CHAIN=true
 # The path can be absolute, or relative to the docker-compose.yml file.
 DATADIR_PATH=./envs/${NETWORK_NAME}/datadir
 
+# If the datadir is on a disk that doesn't support unix domain sockets then you
+# will need to specify a path to a disk that does support unix domain sockets.
+# E.g. your normal hard drive. If left unset the default path inside the
+# datadir will be used.
+IPC_PATH=
+
 # Specifies the endpoint of the eigenda proxy to use. If this is unset then a local eigenda proxy will be used.
 EIGENDA_PROXY_ENDPOINT=https://eigenda-proxy.alfajores.celo-testnet.org
 

--- a/scripts/start-op-geth.sh
+++ b/scripts/start-op-geth.sh
@@ -12,7 +12,9 @@ if [ -n "$OP_GETH__HISTORICAL_RPC" ] || [ -n "$HISTORICAL_RPC_DATADIR_PATH" ] ; 
     export EXTENDED_ARG="${EXTENDED_ARG:-} --rollup.historicalrpc=${OP_GETH__HISTORICAL_RPC:-http://historical-rpc-node:8545}"
 fi
 
-
+if [ -n "$IPC_PATH" ]; then
+  export EXTENDED_ARG="${EXTENDED_ARG:-} --ipcpath=$IPC_PATH"
+fi
 
 # Init genesis if it's a custom chain and the datadir is empty
 if [ -n "${IS_CUSTOM_CHAIN}" ] && [ -z "$(ls -A "$BEDROCK_DATADIR")" ]; then


### PR DESCRIPTION
Allows for configuring the IPC_PATH for situations where the disk holding the datadir does not support unix domain sockets.