### PR TITLE
Run own eigenda-proxy instance as default

### DIFF
--- a/alfajores.env
+++ b/alfajores.env
@@ -55,11 +55,31 @@ DATADIR_PATH=./envs/${NETWORK_NAME}/datadir
 # datadir will be used.
 IPC_PATH=
 
+###############################################################################
+#                            ↓ REQUIRED (EIGENDA) ↓                           #
+###############################################################################
+
 # Specifies the endpoint of the eigenda proxy to use. If this is unset then a local eigenda proxy will be used.
-EIGENDA_PROXY_ENDPOINT=https://eigenda-proxy.alfajores.celo-testnet.org
+EIGENDA_PROXY_ENDPOINT=
 
 # Set to 0 if EIGENDA_PROXY_ENDPOINT is defined otherwise empty. This shouldn't be set manually.
 USE_LOCAL_EIGENDA_PROXY_IF_UNSET=${EIGENDA_PROXY_ENDPOINT:+0}
+
+EIGENDA_LOCAL_DISPERSER_RPC=disperser-holesky.eigenda.xyz:443 
+EIGENDA_LOCAL_SVC_MANAGER_ADDR=0xD4A7E1Bd8015057293f0D0A557088c286942e84b
+
+###############################################################################
+#                            ↓ OPTIONAL (EIGENDA) ↓                           #
+###############################################################################
+
+EIGENDA_LOCAL_S3_CREDENTIAL_TYPE="public"
+EIGENDA_LOCAL_S3_ACCESS_KEY_ID=""
+EIGENDA_LOCAL_S3_ACCESS_KEY_SECRET=""
+EIGENDA_LOCAL_S3_BUCKET="eigenda-proxy-cache-alfajores"
+EIGENDA_LOCAL_S3_PATH="blobs/"
+EIGENDA_LOCAL_S3_ENDPOINT="storage.googleapis.com"
+EIGENDA_LOCAL_ARCHIVE_BLOBS=${EIGENDA_LOCAL_S3_BUCKET:+0}
+
 
 ###############################################################################
 #                                ↓ OPTIONAL ↓                                 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,13 @@ services:
 
   eigenda-proxy:
     platform: linux/amd64
-    image: us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/eigenda-proxy:v1.4.1
+    # Image: ghcr.io/layr-labs/eigenda-proxy:v1.6.3 + fix for public s3 buckets
+    image: us-west1-docker.pkg.dev/devopsre/eigenda-proxy/eigenda-proxy:efe8c51033a4dc0d494ccfdb9f5ffabee7ad0ac9
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-eigenda-proxy.sh
+    env_file:
+      - .env
     volumes:
       - eigenda-data:/data
       - ./scripts/:/scripts

--- a/scripts/start-eigenda-proxy.sh
+++ b/scripts/start-eigenda-proxy.sh
@@ -1,31 +1,25 @@
 #!/bin/sh
 set -e
 
-# Retrieve kzg commitment files, links for points files sourced from:
-# https://github.com/Layr-Labs/eigenda-operator-setup/blob/51857209ab9c49ca8b639d1e9a977d5bff48ecda/srs_setup.sh
-if [ ! -e /data/verified ]; then
-  wget https://srs-mainnet.s3.amazonaws.com/kzg/g1.point --output-document=/data/g1.point
-  wget https://srs-mainnet.s3.amazonaws.com/kzg/g2.point.powerOf2 --output-document=/data/g2.point.powerOf2
-  wget https://raw.githubusercontent.com/Layr-Labs/eigenda-operator-setup/master/resources/srssha256sums.txt --output-document=/data/srssha256sums.txt
-  if (cd data && sha256sum -c srssha256sums.txt); then
-    echo "Checksums match. Verification successful."
-    touch /data/verified
-  else
-    echo "Error: Checksums do not match. Please delete this folder and try again."
-    exit 1
-  fi
+# Archive blobs configuration
+if [ -n "$EIGENDA_LOCAL_ARCHIVE_BLOBS" ]; then
+  export EXTENDED_EIGENDA_PARAMETERS="${EXTENDED_EIGENDA_PARAMETERS:-} --s3.credential-type=$EIGENDA_LOCAL_S3_CREDENTIAL_TYPE \
+  --s3.access-key-id=$EIGENDA_LOCAL_S3_ACCESS_KEY_ID \
+  --s3.access-key-secret=$EIGENDA_LOCAL_S3_ACCESS_KEY_SECRET \
+  --s3.bucket=$EIGENDA_LOCAL_S3_BUCKET \
+  --s3.path=$EIGENDA_LOCAL_S3_PATH \
+  --s3.endpoint=$EIGENDA_LOCAL_S3_ENDPOINT \
+  --storage.fallback-targets=s3"
 fi
 
-exec eigenda-proxy \
-  --addr=0.0.0.0 \
+exec ./eigenda-proxy --addr=0.0.0.0 \
   --port=4242 \
-  --eigenda-disperser-rpc=disperser-holesky.eigenda.xyz:443 \
-  --eigenda-eth-rpc=$OP_NODE__RPC_ENDPOINT \
-  --eigenda-signer-private-key-hex=$(head -c 32 /dev/urandom | xxd -p -c 32) \
-  --eigenda-svc-manager-addr=0xD4A7E1Bd8015057293f0D0A557088c286942e84b \
-  --eigenda-status-query-timeout=45m \
-  --eigenda-g1-path=/data/g1.point \
-  --eigenda-g2-tau-path=/data/g2.point.powerOf2 \
-  --eigenda-disable-tls=false \
-  --eigenda-eth-confirmation-depth=1 \
-  --eigenda-max-blob-length=300MiB
+  --eigenda.disperser-rpc="$EIGENDA_LOCAL_DISPERSER_RPC" \
+  --eigenda.eth-rpc="$OP_NODE__RPC_ENDPOINT" \
+  --eigenda.signer-private-key-hex=$(head -c 32 /dev/urandom | xxd -p -c 32) \
+  --eigenda.svc-manager-addr="$EIGENDA_LOCAL_SVC_MANAGER_ADDR" \
+  --eigenda.status-query-timeout="45m" \
+  --eigenda.disable-tls=false \
+  --eigenda.confirmation-depth=1 \
+  --eigenda.max-blob-length="32MiB" \
+  $EXTENDED_EIGENDA_PARAMETERS

--- a/scripts/start-op-node.sh
+++ b/scripts/start-op-node.sh
@@ -16,7 +16,7 @@ fi
 # OP_NODE_ALTDA_DA_SERVER is picked up by the op-node binary.
 export OP_NODE_ALTDA_DA_SERVER=$EIGENDA_PROXY_ENDPOINT
 if [ -n $USE_LOCAL_EIGENDA_PROXY_IF_UNSET ]; then
-  OP_NODE_ALTDA_DA_SERVER="http://egenda-proxy:4242"
+  OP_NODE_ALTDA_DA_SERVER="http://eigenda-proxy:4242"
 fi
 
 # Start op-node.


### PR DESCRIPTION
* Run own eigenda-proxy instance as default.
* Update image: ghcr.io/layr-labs/eigenda-proxy:v1.6.3 + fix for public s3 buckets
* Config for archive blobs for Alfajores

Tested locally (also removing the disperser to check the s3 fallback)