### PR TITLE
Add `check-db` continuity script to migrate.sh

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -47,11 +47,12 @@ source_dir=$(readlink -f "$source_dir") || { echo "Error: Failed to resolve sour
 destination_dir=$(readlink -f "$destination_dir") || { echo "Error: Failed to resolve destination directory path"; exit 1; }
 
 #TODO(Alec) fix tag for cel2-migration-tool
+cel2_migration_tool_tag="5682b80ec60c47f582c6af8aa085ae6f9048d801"
 
 # Run check-db continuity script to ensure source db has no data gaps
 if docker run --platform=linux/amd64 -it --rm \
     -v "${source_dir}/celo/chaindata:/old-db" \
-    us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool:5682b80ec60c47f582c6af8aa085ae6f9048d801 \
+    "us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool:${cel2_migration_tool_tag}" \
     check-db \
       --db-path /old-db \
       --fail-fast; then
@@ -68,7 +69,7 @@ if [ "${operation}" = "pre" ]; then
   docker run --platform=linux/amd64 -it --rm \
     -v "${source_dir}/celo/chaindata:/old-db" \
     -v "${destination_dir}/geth/chaindata:/new-db" \
-    us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool:5682b80ec60c47f582c6af8aa085ae6f9048d801 \
+    "us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool:${cel2_migration_tool_tag}" \
     "${operation}" \
       --old-db /old-db \
       --new-db /new-db
@@ -100,7 +101,7 @@ docker run --platform=linux/amd64 -it --rm \
   -v "${destination_dir}/geth/chaindata:/new-db" \
   -v "${migration_config_dir}:/migration-config" \
   -v "./envs/${network}/config:/out-config" \
-  us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool:5682b80ec60c47f582c6af8aa085ae6f9048d801 \
+  "us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool:${cel2_migration_tool_tag}" \
   "${operation}" \
     --old-db /old-db \
     --new-db /new-db \

--- a/migrate.sh
+++ b/migrate.sh
@@ -68,9 +68,9 @@ if docker run --platform=linux/amd64 -it --rm \
     check-db \
       --db-path /old-db \
       --fail-fast; then
-    printf "\033[0;32mDB check completed successfully.\033[0m\n"
+    printf "\033[0;32mDB check completed successfully. No gaps / missing data detected.\033[0m\n"
 else
-    printf "\033[0;31mDB check failed with exit code $?. The source db is missing data. Please retry with another source db, and visit https://docs.celo.org/cel2/operators/migrate-node for instructions on how to check for missing data.\033[0m\n"
+    printf "\033[0;31mDB check failed with exit code $?. If the logs indicate that the db is missing data, please retry with another source db. You can visit https://docs.celo.org/cel2/operators/migrate-node for instructions on how to check whether a db has missing data.\033[0m\n"
     exit $?
 fi
 

--- a/migrate.sh
+++ b/migrate.sh
@@ -55,11 +55,8 @@ if ! is_absolute_path "$source_dir"; then
     source_dir=$(readlink -f "$source_dir") || { echo "Error: Failed to resolve source directory path, directory may not exist"; exit 1; }
 fi
 
-#TODO(Alec) fix tag for cel2-migration-tool
-cel2_migration_tool_image="us-west1-docker.pkg.dev/devopsre/dev-images/cel2-migration-tool"
-#cel2_migration_tool_image="us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool"
-cel2_migration_tool_tag="5bde0aeb2ec9afa96c991c78775766e5981dc796"
-#cel2_migration_tool_tag="5682b80ec60c47f582c6af8aa085ae6f9048d801"
+cel2_migration_tool_image="us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool"
+cel2_migration_tool_tag="5682b80ec60c47f582c6af8aa085ae6f9048d801"
 
 # Run check-db continuity script to ensure source db has no data gaps
 if docker run --platform=linux/amd64 -it --rm \

--- a/migrate.sh
+++ b/migrate.sh
@@ -43,7 +43,7 @@ echo "Destination Directory: $destination_dir"
 echo "" # Blank line to separate from any failure output
 
 # Check if source directory exists
-if ![ -d "${source_dir}" ]; then
+if [ ! -d "${source_dir}" ]; then
     printf "\033[0;31mError: Source directory does not exist\033[0m\n"
     exit 1
 fi

--- a/migrate.sh
+++ b/migrate.sh
@@ -63,7 +63,7 @@ cel2_migration_tool_tag="5bde0aeb2ec9afa96c991c78775766e5981dc796"
 
 # Run check-db continuity script to ensure source db has no data gaps
 if docker run --platform=linux/amd64 -it --rm \
-    -v "${source_dir}:/old-db" \
+    -v "${source_dir}/celo/chaindata:/old-db" \
     "${cel2_migration_tool_image}:${cel2_migration_tool_tag}" \
     check-db \
       --db-path /old-db \

--- a/migrate.sh
+++ b/migrate.sh
@@ -46,6 +46,8 @@ echo "" # Blank line to separate from any failure output
 source_dir=$(readlink -f "$source_dir") || { echo "Error: Failed to resolve source directory path"; exit 1; }
 destination_dir=$(readlink -f "$destination_dir") || { echo "Error: Failed to resolve destination directory path"; exit 1; }
 
+#TODO(Alec) fix tag for cel2-migration-tool
+
 # Run check-db continuity script to ensure source db has no data gaps
 if docker run --platform=linux/amd64 -it --rm \
     -v "${source_dir}/celo/chaindata:/old-db" \

--- a/migrate.sh
+++ b/migrate.sh
@@ -75,7 +75,7 @@ else
 fi
 
 # Ensure destination directory exists for chaindata
-mkdir -p  "${destination_dir}/geth"
+mkdir -p  "${destination_dir}/geth/chaindata"
 
 # Convert destination directory to absolute path if relative
 if ! is_absolute_path "$destination_dir"; then

--- a/migrate.sh
+++ b/migrate.sh
@@ -47,12 +47,15 @@ source_dir=$(readlink -f "$source_dir") || { echo "Error: Failed to resolve sour
 destination_dir=$(readlink -f "$destination_dir") || { echo "Error: Failed to resolve destination directory path"; exit 1; }
 
 #TODO(Alec) fix tag for cel2-migration-tool
-cel2_migration_tool_tag="5682b80ec60c47f582c6af8aa085ae6f9048d801"
+cel2_migration_tool_image="us-west1-docker.pkg.dev/devopsre/dev-images/cel2-migration-tool"
+#cel2_migration_tool_image="us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool"
+cel2_migration_tool_tag="5bde0aeb2ec9afa96c991c78775766e5981dc796"
+#cel2_migration_tool_tag="5682b80ec60c47f582c6af8aa085ae6f9048d801"
 
 # Run check-db continuity script to ensure source db has no data gaps
 if docker run --platform=linux/amd64 -it --rm \
-    -v "${source_dir}/celo/chaindata:/old-db" \
-    "us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool:${cel2_migration_tool_tag}" \
+    -v "${source_dir}:/old-db" \
+    "${cel2_migration_tool_image}:${cel2_migration_tool_tag}" \
     check-db \
       --db-path /old-db \
       --fail-fast; then
@@ -69,7 +72,7 @@ if [ "${operation}" = "pre" ]; then
   docker run --platform=linux/amd64 -it --rm \
     -v "${source_dir}/celo/chaindata:/old-db" \
     -v "${destination_dir}/geth/chaindata:/new-db" \
-    "us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool:${cel2_migration_tool_tag}" \
+    "${cel2_migration_tool_image}:${cel2_migration_tool_tag}" \
     "${operation}" \
       --old-db /old-db \
       --new-db /new-db
@@ -101,7 +104,7 @@ docker run --platform=linux/amd64 -it --rm \
   -v "${destination_dir}/geth/chaindata:/new-db" \
   -v "${migration_config_dir}:/migration-config" \
   -v "./envs/${network}/config:/out-config" \
-  "us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool:${cel2_migration_tool_tag}" \
+  "${cel2_migration_tool_image}:${cel2_migration_tool_tag}" \
   "${operation}" \
     --old-db /old-db \
     --new-db /new-db \


### PR DESCRIPTION
Adds a call to the check-db script in celo-migrate to migrate.sh. This checks for gaps in the source directory and exits immediately if gaps are found.

Adds some drive-by changes for things that came up during testing:
- destination dir path should include "chaindata"
- calls to `readlink` fail if path does not exist, so we check that the source directory exists before calling readlink on it 

Tested locally using a baklava datadir with gaps and a baklava datadir without gaps 

Addresses non-docs part of https://github.com/celo-org/celo-blockchain-planning/issues/897. Will put up a docs PR as well. 