### PR TITLE
First 32 bytes more portable in `scripts/start-op-get.sh`

### DIFF
--- a/scripts/start-op-geth.sh
+++ b/scripts/start-op-geth.sh
@@ -5,7 +5,7 @@ set -e
 if [ ! -f "/shared/jwt.txt" ]; then
   echo "Creating JWT..."
   mkdir -p /shared
-  head -c 32 /dev/urandom | xxd -p -c 32 > /shared/jwt.txt
+  dd bs=1 count=32 if=/dev/urandom of=/dev/stdout | xxd -p -c 32 > /shared/jwt.txt
 fi
 
 # Check if either OP_GETH__HISTORICAL_RPC or HISTORICAL_RPC_DATADIR_PATH is set and if so set the historical rpc option.


### PR DESCRIPTION
The paramter -c in `head` is specific to GNU head but not of POSIX https://pubs.opengroup.org/onlinepubs/9699919799/utilities/head.html
And at least it doesn't work on OpenBSD/adJ.

This patch implements a more portable way to extract first 32 bytes of a sequence.