### PR TITLE
Update eigenda-proxy to v1.6.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,7 @@ services:
 
   eigenda-proxy:
     platform: linux/amd64
-    # Image: ghcr.io/layr-labs/eigenda-proxy:v1.6.3 + fix for public s3 buckets
-    image: us-west1-docker.pkg.dev/devopsre/eigenda-proxy/eigenda-proxy:efe8c51033a4dc0d494ccfdb9f5ffabee7ad0ac9
+    image: ghcr.io/layr-labs/eigenda-proxy:v1.6.4
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-eigenda-proxy.sh


### PR DESCRIPTION
Update eigenda-proxy to the upstream image 1.6.4

The v1.6.4 has a fix for a default value that could led to an invalid cert after a 1-block reorg on holesky (more info: https://github.com/Layr-Labs/eigenda-proxy/releases)

Also, return to the upstream image, because the PR for public s3 buckets is part of this v1.6.4