### PR TITLE
Ensure migration script outputs rollup.json with chain_op_config included.

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -51,8 +51,8 @@ fi
 # Convert source directory to absolute path
 source_dir=$(readlink -f "$source_dir")
 
-cel2_migration_tool_image="us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool"
-cel2_migration_tool_tag="5682b80ec60c47f582c6af8aa085ae6f9048d801"
+cel2_migration_tool_image="us-west1-docker.pkg.dev/devopsre/dev-images/cel2-migration-tool"
+cel2_migration_tool_tag="db2da1310e6d5e371709b8cda8bbcf59dece1c86"
 
 # Run check-db continuity script to ensure source db has no data gaps
 if docker run --platform=linux/amd64 -it --rm \

--- a/migrate.sh
+++ b/migrate.sh
@@ -51,8 +51,8 @@ fi
 # Convert source directory to absolute path
 source_dir=$(readlink -f "$source_dir")
 
-cel2_migration_tool_image="us-west1-docker.pkg.dev/devopsre/dev-images/cel2-migration-tool"
-cel2_migration_tool_tag="db2da1310e6d5e371709b8cda8bbcf59dece1c86"
+cel2_migration_tool_image="us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/cel2-migration-tool"
+cel2_migration_tool_tag="celo-v2.0.0-rc4"
 
 # Run check-db continuity script to ensure source db has no data gaps
 if docker run --platform=linux/amd64 -it --rm \


### PR DESCRIPTION
Updates the migration tool docker image, this ensures that we
are using code that includes the chain_op_config field in the rollup
config, the code itself was added by the optimism team.

Closes https://github.com/celo-org/celo-blockchain-planning/issues/911

# Tested
Locally, I see the updated config being generated.