### PR TITLE
Add new environment variables MONITORING_ENABLED/GRAFANA_RESTART_POLI…

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ Hours until sync completed: ...
 Grafana is exposed at [http://localhost:3000](http://localhost:3000) and comes with one pre-loaded dashboard ("Simple Node Dashboard").
 Simple Node Dashboard includes basic node information and will tell you if your node ever falls out of sync with the reference L2 node or if a state root fault is detected.
 
+By default, Grafana and Prometheus do not start (`MONITORING_ENABLED=false`). If you want to launch Grafana and Prometheus, set `MONITORING_ENABLED=true` in your environment file. You can also control the containers’ restart policies using `GRAFANA_RESTART_POLICY`/`PROMETHEUS_RESTART_POLICY` (e.g.  `unless-stopped`, `no`, `always`, or `on-failure`).
+
 Use the following login details to access the dashboard:
 
 - Username: `admin`

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Hours until sync completed: ...
 Grafana is exposed at [http://localhost:3000](http://localhost:3000) and comes with one pre-loaded dashboard ("Simple Node Dashboard").
 Simple Node Dashboard includes basic node information and will tell you if your node ever falls out of sync with the reference L2 node or if a state root fault is detected.
 
-By default, Grafana and Prometheus do not start (`MONITORING_ENABLED=false`). If you want to launch Grafana and Prometheus, set `MONITORING_ENABLED=true` in your environment file. You can also control the containers’ restart policies using `GRAFANA_RESTART_POLICY`/`PROMETHEUS_RESTART_POLICY` (e.g.  `unless-stopped`, `no`, `always`, or `on-failure`).
+By default, Grafana and Prometheus do not start (`MONITORING_ENABLED=false`). If you want to launch Grafana and Prometheus, set `MONITORING_ENABLED=true` in your environment file
 
 Use the following login details to access the dashboard:
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o 
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 sudo apt-get update
-
+ 
 ### Install docker and docker compose on Ubuntu
 sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
 sudo usermod -aG docker $(whoami)
-
+ 
 ### Verify the Docker and docker compose install on Ubuntu
 sudo docker run hello-world
 ```
@@ -86,7 +86,6 @@ E.g. to run a node on Alfajores:
 ```sh
 cp alfajores.env .env
 ```
-
 The `.env` file is ready to use and is configured for snap sync and non-archive mode. If you would like to customise
 your node further see below.
 
@@ -95,61 +94,61 @@ your node further see below.
 There are some choices that significantly affect how nodes need to be run. The
 requirements for each are given below.
 
-- Snap sync node:
-  - No extra requirements, simply use the provided config.
-- Full sync node:
-  - A datadir migrated from an L1 node (this does not need to be an archive datadir)
-  - Full sync configured
-  - Example config adjustments:
-    - ```
-      OP_GETH__SYNCMODE=full
-      DATADIR_PATH=<path to your migrated datadir>
-      ```
-- Historical archive access (historical execution and state access, e.g.
+* Snap sync node:
+  * No extra requirements, simply use the provided config.
+* Full sync node:
+   * A datadir migrated from an L1 node (this does not need to be an archive datadir)
+   * Full sync configured
+   * Example config adjustments:
+     * ```
+       OP_GETH__SYNCMODE=full
+       DATADIR_PATH=<path to your migrated datadir>
+       ```
+* Historical archive access (historical execution and state access, e.g.
   `eth_call`, `eth_getBalance` ... etc for pre-L2 blocks)
-  - Requires access to an L1 archive node, this can be achieved in one of 3 ways:
-    - An existing L1 archive node datadir can be configured and an L1 node
-      will be launched using that datadir
-    - An empty datadir can be configured and an L1 archive node will be launched
-      and sync using that datadir. Note that it will be some time till the L1
-      node will be able to serve state queries
-    - An L1 archive node URL can be configured
-  - Example config adjustments:
-    - ```
-      HISTORICAL_RPC_DATADIR_PATH=<path to datadir> or OP_GETH__HISTORICAL_RPC=<historical rpc node endpoint>
-      ```
-- Full archive node with all states from genesis stored:
-  - A datadir migrated from an L1 node (this does not need to be an archive datadir)
-  - Full sync configured
-  - Historical archive access configured (see above)
-  - Example config adjustments:
-    - ```
-      OP_GETH__SYNCMODE=full
-      DATADIR_PATH=<path to your migrated datadir>
-      HISTORICAL_RPC_DATADIR_PATH=<path to datadir> or OP_GETH__HISTORICAL_RPC=<historical rpc node endpoint>
-      ```
+   * Requires access to an L1 archive node, this can be achieved in one of 3 ways:
+     * An existing L1 archive node datadir can be configured and an L1 node
+       will be launched using that datadir
+     * An empty datadir can be configured and an L1 archive node will be launched
+       and sync using that datadir. Note that it will be some time till the L1
+       node will be able to serve state queries
+     * An L1 archive node URL can be configured
+   * Example config adjustments:
+     * ```
+       HISTORICAL_RPC_DATADIR_PATH=<path to datadir> or OP_GETH__HISTORICAL_RPC=<historical rpc node endpoint>
+       ```
+* Full archive node with all states from genesis stored:
+   * A datadir migrated from an L1 node (this does not need to be an archive datadir)
+   * Full sync configured
+   * Historical archive access configured (see above)
+   * Example config adjustments:
+     * ```
+       OP_GETH__SYNCMODE=full
+       DATADIR_PATH=<path to your migrated datadir>
+       HISTORICAL_RPC_DATADIR_PATH=<path to datadir> or OP_GETH__HISTORICAL_RPC=<historical rpc node endpoint>
+       ```
 
 See [Obtaining a migrated L1 datadir](#obtaining-a-migrated-l1-datadir) for
 instructions on obtaining a migrated L1 datadir.
 
 ### Optional configurations
 
-- **NODE_TYPE** - Choose the type of node you want to run:
-  - `full` (Full node) - A Full node contains a few recent blocks without historical states.
-  - `archive` (Archive node) - An Archive node stores the complete history of the blockchain, including historical states.
-- **OP_NODE\_\_RPC_ENDPOINT** - Specify the endpoint for the RPC of Layer 1 (e.g., Ethereum mainnet). For instance, you can use the free plan of Alchemy for the Ethereum mainnet.
-- **OP_NODE\_\_L1_BEACON** - Specify the beacon endpoint of Layer 1. You can use [QuickNode for the beacon endpoint](https://www.quicknode.com). For example: https://xxx-xxx-xxx.quiknode.pro/db55a3908ba7e4e5756319ffd71ec270b09a7dce
-- **OP_NODE\_\_RPC_TYPE** - Specify the service provider for the RPC endpoint you've chosen in the previous step. The available options are:
-  - `alchemy` - Alchemy
-  - `quicknode` - Quicknode (ETH only)
-  - `erigon` - Erigon
-  - `basic` - Other providers
-- **HEALTHCHECK\_\_REFERENCE_RPC_PROVIDER** - Specify the public RPC endpoint for Layer 2 network you want to operate on for healthchecking.
-- **HISTORICAL_RPC_DATADIR_PATH** - Datadir path to use for historical RPC node to serve pre-L2 historical state.
-- **OP_GETH\_\_HISTORICAL_RPC** - RPC Endpoint for fetching pre-L2 historical state, if set overrides the **HISTORICAL_RPC_DATADIR_PATH** setting.
-  - Leave blank if you want to self-host pre-bedrock historical node for high-throughput use cases such as subgraph indexing.
-- **IMAGE_TAG\_\_[...]** - Use custom docker image for specified components.
-- **PORT\_\_[...]** - Use custom port for specified components.
+* **NODE_TYPE** - Choose the type of node you want to run:
+    * `full` (Full node) - A Full node contains a few recent blocks without historical states.
+    * `archive` (Archive node) - An Archive node stores the complete history of the blockchain, including historical states.
+* **OP_NODE__RPC_ENDPOINT** - Specify the endpoint for the RPC of Layer 1 (e.g., Ethereum mainnet). For instance, you can use the free plan of Alchemy for the Ethereum mainnet.
+* **OP_NODE__L1_BEACON** - Specify the beacon endpoint of Layer 1. You can use [QuickNode for the beacon endpoint](https://www.quicknode.com). For example: https://xxx-xxx-xxx.quiknode.pro/db55a3908ba7e4e5756319ffd71ec270b09a7dce
+* **OP_NODE__RPC_TYPE** - Specify the service provider for the RPC endpoint you've chosen in the previous step. The available options are:
+    * `alchemy` - Alchemy
+    * `quicknode` - Quicknode (ETH only)
+    * `erigon` - Erigon
+    * `basic` - Other providers
+* **HEALTHCHECK__REFERENCE_RPC_PROVIDER** - Specify the public RPC endpoint for Layer 2 network you want to operate on for healthchecking.
+* **HISTORICAL_RPC_DATADIR_PATH** - Datadir path to use for historical RPC node to serve pre-L2 historical state.
+* **OP_GETH__HISTORICAL_RPC** - RPC Endpoint for fetching pre-L2 historical state, if set overrides the **HISTORICAL_RPC_DATADIR_PATH** setting.
+    * Leave blank if you want to self-host pre-bedrock historical node for high-throughput use cases such as subgraph indexing.
+* **IMAGE_TAG__[...]** - Use custom docker image for specified components.
+* **PORT__[...]** - Use custom port for specified components.
 
 ## Obtaining a migrated L1 datadir
 
@@ -161,9 +160,9 @@ one by following one of the options outlined below.
 If you do not have an existing L1 datadir but wish to full sync and/or run an
 archive node you can download a migrated datadir hosted by cLabs from one of the links below.
 
-- [Alfajores migrated datadir](https://storage.googleapis.com/cel2-rollup-files/alfajores/alfajores-migrated-datadir.tar.zst)
-- Baklava migrated datadir - pending network launch
-- Mainnet migrated datadir - pending network launch
+* [Alfajores migrated datadir](https://storage.googleapis.com/cel2-rollup-files/alfajores/alfajores-migrated-datadir.tar.zst)
+* Baklava migrated datadir - pending network launch
+* Mainnet migrated datadir - pending network launch
 
 ### 2. Migrate your own datadir
 
@@ -230,10 +229,9 @@ docker compose logs <CONTAINER_NAME> -f --tail 10
 ```
 
 To view logs for a specific container. Most commonly used `<CONTAINER_NAME>` are:
-
-- op-geth
-- op-node
-- bedrock-init
+* op-geth
+* op-node
+* bedrock-init
 
 ### Stop
 
@@ -327,14 +325,14 @@ These assets are fetched when required by the scripts in this repo and so
 should not need to be manually retrieved, however for completeness they are
 provided here.
 
-- Mainnet
-- Pending launch
-- Alfajores - L2 fork block 26384000
-  - [Full migrated chaindata](https://storage.googleapis.com/cel2-rollup-files/alfajores/alfajores-migrated-datadir.tar.zst)
-  - [Rollup deploy config](https://storage.googleapis.com/cel2-rollup-files/alfajores/config.json)
-  - [L1 contract addresses](https://storage.googleapis.com/cel2-rollup-files/alfajores/deployment-l1.json)
-  - [L2 allocs](https://storage.googleapis.com/cel2-rollup-files/alfajores/l2-allocs.json)
-  - [rollup.json](https://storage.googleapis.com/cel2-rollup-files/alfajores/rollup.json)
-  - [Genesis](https://storage.googleapis.com/cel2-rollup-files/alfajores/genesis.json) used for snap syncing
-- Baklava
-- Pending launch
+* Mainnet
+ * Pending launch
+* Alfajores - L2 fork block 26384000
+  * [Full migrated chaindata](https://storage.googleapis.com/cel2-rollup-files/alfajores/alfajores-migrated-datadir.tar.zst)
+  * [Rollup deploy config](https://storage.googleapis.com/cel2-rollup-files/alfajores/config.json)
+  * [L1 contract addresses](https://storage.googleapis.com/cel2-rollup-files/alfajores/deployment-l1.json)
+  * [L2 allocs](https://storage.googleapis.com/cel2-rollup-files/alfajores/l2-allocs.json)
+  * [rollup.json](https://storage.googleapis.com/cel2-rollup-files/alfajores/rollup.json)
+  * [Genesis](https://storage.googleapis.com/cel2-rollup-files/alfajores/genesis.json) used for snap syncing
+* Baklava
+ * Pending launch

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o 
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 sudo apt-get update
- 
+
 ### Install docker and docker compose on Ubuntu
 sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
 sudo usermod -aG docker $(whoami)
- 
+
 ### Verify the Docker and docker compose install on Ubuntu
 sudo docker run hello-world
 ```
@@ -86,6 +86,7 @@ E.g. to run a node on Alfajores:
 ```sh
 cp alfajores.env .env
 ```
+
 The `.env` file is ready to use and is configured for snap sync and non-archive mode. If you would like to customise
 your node further see below.
 
@@ -94,61 +95,61 @@ your node further see below.
 There are some choices that significantly affect how nodes need to be run. The
 requirements for each are given below.
 
-* Snap sync node:
-  * No extra requirements, simply use the provided config.
-* Full sync node:
-   * A datadir migrated from an L1 node (this does not need to be an archive datadir)
-   * Full sync configured
-   * Example config adjustments:
-     * ```
-       OP_GETH__SYNCMODE=full
-       DATADIR_PATH=<path to your migrated datadir>
-       ```
-* Historical archive access (historical execution and state access, e.g.
+- Snap sync node:
+  - No extra requirements, simply use the provided config.
+- Full sync node:
+  - A datadir migrated from an L1 node (this does not need to be an archive datadir)
+  - Full sync configured
+  - Example config adjustments:
+    - ```
+      OP_GETH__SYNCMODE=full
+      DATADIR_PATH=<path to your migrated datadir>
+      ```
+- Historical archive access (historical execution and state access, e.g.
   `eth_call`, `eth_getBalance` ... etc for pre-L2 blocks)
-   * Requires access to an L1 archive node, this can be achieved in one of 3 ways:
-     * An existing L1 archive node datadir can be configured and an L1 node
-       will be launched using that datadir
-     * An empty datadir can be configured and an L1 archive node will be launched
-       and sync using that datadir. Note that it will be some time till the L1
-       node will be able to serve state queries
-     * An L1 archive node URL can be configured
-   * Example config adjustments:
-     * ```
-       HISTORICAL_RPC_DATADIR_PATH=<path to datadir> or OP_GETH__HISTORICAL_RPC=<historical rpc node endpoint>
-       ```
-* Full archive node with all states from genesis stored:
-   * A datadir migrated from an L1 node (this does not need to be an archive datadir)
-   * Full sync configured
-   * Historical archive access configured (see above)
-   * Example config adjustments:
-     * ```
-       OP_GETH__SYNCMODE=full
-       DATADIR_PATH=<path to your migrated datadir>
-       HISTORICAL_RPC_DATADIR_PATH=<path to datadir> or OP_GETH__HISTORICAL_RPC=<historical rpc node endpoint>
-       ```
+  - Requires access to an L1 archive node, this can be achieved in one of 3 ways:
+    - An existing L1 archive node datadir can be configured and an L1 node
+      will be launched using that datadir
+    - An empty datadir can be configured and an L1 archive node will be launched
+      and sync using that datadir. Note that it will be some time till the L1
+      node will be able to serve state queries
+    - An L1 archive node URL can be configured
+  - Example config adjustments:
+    - ```
+      HISTORICAL_RPC_DATADIR_PATH=<path to datadir> or OP_GETH__HISTORICAL_RPC=<historical rpc node endpoint>
+      ```
+- Full archive node with all states from genesis stored:
+  - A datadir migrated from an L1 node (this does not need to be an archive datadir)
+  - Full sync configured
+  - Historical archive access configured (see above)
+  - Example config adjustments:
+    - ```
+      OP_GETH__SYNCMODE=full
+      DATADIR_PATH=<path to your migrated datadir>
+      HISTORICAL_RPC_DATADIR_PATH=<path to datadir> or OP_GETH__HISTORICAL_RPC=<historical rpc node endpoint>
+      ```
 
 See [Obtaining a migrated L1 datadir](#obtaining-a-migrated-l1-datadir) for
 instructions on obtaining a migrated L1 datadir.
 
 ### Optional configurations
 
-* **NODE_TYPE** - Choose the type of node you want to run:
-    * `full` (Full node) - A Full node contains a few recent blocks without historical states.
-    * `archive` (Archive node) - An Archive node stores the complete history of the blockchain, including historical states.
-* **OP_NODE__RPC_ENDPOINT** - Specify the endpoint for the RPC of Layer 1 (e.g., Ethereum mainnet). For instance, you can use the free plan of Alchemy for the Ethereum mainnet.
-* **OP_NODE__L1_BEACON** - Specify the beacon endpoint of Layer 1. You can use [QuickNode for the beacon endpoint](https://www.quicknode.com). For example: https://xxx-xxx-xxx.quiknode.pro/db55a3908ba7e4e5756319ffd71ec270b09a7dce
-* **OP_NODE__RPC_TYPE** - Specify the service provider for the RPC endpoint you've chosen in the previous step. The available options are:
-    * `alchemy` - Alchemy
-    * `quicknode` - Quicknode (ETH only)
-    * `erigon` - Erigon
-    * `basic` - Other providers
-* **HEALTHCHECK__REFERENCE_RPC_PROVIDER** - Specify the public RPC endpoint for Layer 2 network you want to operate on for healthchecking.
-* **HISTORICAL_RPC_DATADIR_PATH** - Datadir path to use for historical RPC node to serve pre-L2 historical state.
-* **OP_GETH__HISTORICAL_RPC** - RPC Endpoint for fetching pre-L2 historical state, if set overrides the **HISTORICAL_RPC_DATADIR_PATH** setting.
-    * Leave blank if you want to self-host pre-bedrock historical node for high-throughput use cases such as subgraph indexing.
-* **IMAGE_TAG__[...]** - Use custom docker image for specified components.
-* **PORT__[...]** - Use custom port for specified components.
+- **NODE_TYPE** - Choose the type of node you want to run:
+  - `full` (Full node) - A Full node contains a few recent blocks without historical states.
+  - `archive` (Archive node) - An Archive node stores the complete history of the blockchain, including historical states.
+- **OP_NODE\_\_RPC_ENDPOINT** - Specify the endpoint for the RPC of Layer 1 (e.g., Ethereum mainnet). For instance, you can use the free plan of Alchemy for the Ethereum mainnet.
+- **OP_NODE\_\_L1_BEACON** - Specify the beacon endpoint of Layer 1. You can use [QuickNode for the beacon endpoint](https://www.quicknode.com). For example: https://xxx-xxx-xxx.quiknode.pro/db55a3908ba7e4e5756319ffd71ec270b09a7dce
+- **OP_NODE\_\_RPC_TYPE** - Specify the service provider for the RPC endpoint you've chosen in the previous step. The available options are:
+  - `alchemy` - Alchemy
+  - `quicknode` - Quicknode (ETH only)
+  - `erigon` - Erigon
+  - `basic` - Other providers
+- **HEALTHCHECK\_\_REFERENCE_RPC_PROVIDER** - Specify the public RPC endpoint for Layer 2 network you want to operate on for healthchecking.
+- **HISTORICAL_RPC_DATADIR_PATH** - Datadir path to use for historical RPC node to serve pre-L2 historical state.
+- **OP_GETH\_\_HISTORICAL_RPC** - RPC Endpoint for fetching pre-L2 historical state, if set overrides the **HISTORICAL_RPC_DATADIR_PATH** setting.
+  - Leave blank if you want to self-host pre-bedrock historical node for high-throughput use cases such as subgraph indexing.
+- **IMAGE_TAG\_\_[...]** - Use custom docker image for specified components.
+- **PORT\_\_[...]** - Use custom port for specified components.
 
 ## Obtaining a migrated L1 datadir
 
@@ -160,9 +161,9 @@ one by following one of the options outlined below.
 If you do not have an existing L1 datadir but wish to full sync and/or run an
 archive node you can download a migrated datadir hosted by cLabs from one of the links below.
 
-* [Alfajores migrated datadir](https://storage.googleapis.com/cel2-rollup-files/alfajores/alfajores-migrated-datadir.tar.zst)
-* Baklava migrated datadir - pending network launch
-* Mainnet migrated datadir - pending network launch
+- [Alfajores migrated datadir](https://storage.googleapis.com/cel2-rollup-files/alfajores/alfajores-migrated-datadir.tar.zst)
+- Baklava migrated datadir - pending network launch
+- Mainnet migrated datadir - pending network launch
 
 ### 2. Migrate your own datadir
 
@@ -229,9 +230,10 @@ docker compose logs <CONTAINER_NAME> -f --tail 10
 ```
 
 To view logs for a specific container. Most commonly used `<CONTAINER_NAME>` are:
-* op-geth
-* op-node
-* bedrock-init
+
+- op-geth
+- op-node
+- bedrock-init
 
 ### Stop
 
@@ -272,6 +274,17 @@ Will shut down the node and WIPE ALL DATA. Proceed with caution!
 
 ## Monitoring
 
+### Conditional Start of Monitoring Services
+
+The following monitoring-related services:
+
+- `healthcheck`
+- `prometheus`
+- `grafana`
+- `influxdb`
+
+will only start if the environment variable `MONITORING_ENABLED` is set to `true`
+
 ### Estimate remaining sync time
 
 Install foundry following the instructions of
@@ -297,8 +310,6 @@ Hours until sync completed: ...
 Grafana is exposed at [http://localhost:3000](http://localhost:3000) and comes with one pre-loaded dashboard ("Simple Node Dashboard").
 Simple Node Dashboard includes basic node information and will tell you if your node ever falls out of sync with the reference L2 node or if a state root fault is detected.
 
-By default, Grafana and Prometheus do not start (`MONITORING_ENABLED=false`). If you want to launch Grafana and Prometheus, set `MONITORING_ENABLED=true` in your environment file
-
 Use the following login details to access the dashboard:
 
 - Username: `admin`
@@ -316,14 +327,14 @@ These assets are fetched when required by the scripts in this repo and so
 should not need to be manually retrieved, however for completeness they are
 provided here.
 
-* Mainnet
- * Pending launch
-* Alfajores - L2 fork block 26384000
-  * [Full migrated chaindata](https://storage.googleapis.com/cel2-rollup-files/alfajores/alfajores-migrated-datadir.tar.zst)
-  * [Rollup deploy config](https://storage.googleapis.com/cel2-rollup-files/alfajores/config.json)
-  * [L1 contract addresses](https://storage.googleapis.com/cel2-rollup-files/alfajores/deployment-l1.json)
-  * [L2 allocs](https://storage.googleapis.com/cel2-rollup-files/alfajores/l2-allocs.json)
-  * [rollup.json](https://storage.googleapis.com/cel2-rollup-files/alfajores/rollup.json)
-  * [Genesis](https://storage.googleapis.com/cel2-rollup-files/alfajores/genesis.json) used for snap syncing
-* Baklava
- * Pending launch
+- Mainnet
+- Pending launch
+- Alfajores - L2 fork block 26384000
+  - [Full migrated chaindata](https://storage.googleapis.com/cel2-rollup-files/alfajores/alfajores-migrated-datadir.tar.zst)
+  - [Rollup deploy config](https://storage.googleapis.com/cel2-rollup-files/alfajores/config.json)
+  - [L1 contract addresses](https://storage.googleapis.com/cel2-rollup-files/alfajores/deployment-l1.json)
+  - [L2 allocs](https://storage.googleapis.com/cel2-rollup-files/alfajores/l2-allocs.json)
+  - [rollup.json](https://storage.googleapis.com/cel2-rollup-files/alfajores/rollup.json)
+  - [Genesis](https://storage.googleapis.com/cel2-rollup-files/alfajores/genesis.json) used for snap syncing
+- Baklava
+- Pending launch

--- a/alfajores.env
+++ b/alfajores.env
@@ -85,6 +85,15 @@ EIGENDA_LOCAL_ARCHIVE_BLOBS=${EIGENDA_LOCAL_S3_BUCKET:+0}
 #                                ↓ OPTIONAL ↓                                 #
 ###############################################################################
 
+# MONITORING_ENABLED controls whether Grafana and Prometheus are started
+# Set to "true" if you want to launch them, otherwise keep "false"
+MONITORING_ENABLED=false
+
+# GRAFANA_RESTART_POLICY/PROMETHEUS_RESTART_POLICY set the Docker Compose 'restart' policy for Grafana/Prometheus
+# (e.g. 'no', 'always', 'on-failure', or 'unless-stopped')
+GRAFANA_RESTART_POLICY=no
+PROMETHEUS_RESTART_POLICY=no
+
 IMAGE_TAG__HEALTCHECK=
 IMAGE_TAG__PROMETHEUS=
 IMAGE_TAG__GRAFANA=

--- a/alfajores.env
+++ b/alfajores.env
@@ -89,11 +89,6 @@ EIGENDA_LOCAL_ARCHIVE_BLOBS=${EIGENDA_LOCAL_S3_BUCKET:+0}
 # Set to "true" if you want to launch them, otherwise keep "false"
 MONITORING_ENABLED=false
 
-# GRAFANA_RESTART_POLICY/PROMETHEUS_RESTART_POLICY set the Docker Compose 'restart' policy for Grafana/Prometheus
-# (e.g. 'no', 'always', 'on-failure', or 'unless-stopped')
-GRAFANA_RESTART_POLICY=no
-PROMETHEUS_RESTART_POLICY=no
-
 IMAGE_TAG__HEALTCHECK=
 IMAGE_TAG__PROMETHEUS=
 IMAGE_TAG__GRAFANA=

--- a/alfajores.env
+++ b/alfajores.env
@@ -85,7 +85,7 @@ EIGENDA_LOCAL_ARCHIVE_BLOBS=${EIGENDA_LOCAL_S3_BUCKET:+0}
 #                                ↓ OPTIONAL ↓                                 #
 ###############################################################################
 
-# MONITORING_ENABLED controls whether Grafana and Prometheus are started
+# MONITORING_ENABLED controls whether Grafana, Prometheus, Influxdb, and Healthcheck are started
 # Set to "true" if you want to launch them, otherwise keep "false"
 MONITORING_ENABLED=false
 

--- a/baklava.env
+++ b/baklava.env
@@ -84,6 +84,15 @@ EIGENDA_LOCAL_ARCHIVE_BLOBS=${EIGENDA_LOCAL_S3_BUCKET:+0}
 #                                ↓ OPTIONAL ↓                                 #
 ###############################################################################
 
+# MONITORING_ENABLED controls whether Grafana and Prometheus are started
+# Set to "true" if you want to launch them, otherwise keep "false"
+MONITORING_ENABLED=false
+
+# GRAFANA_RESTART_POLICY/PROMETHEUS_RESTART_POLICY set the Docker Compose 'restart' policy for Grafana/Prometheus
+# (e.g. 'no', 'always', 'on-failure', or 'unless-stopped')
+GRAFANA_RESTART_POLICY=no
+PROMETHEUS_RESTART_POLICY=no
+
 IMAGE_TAG__HEALTCHECK=
 IMAGE_TAG__PROMETHEUS=
 IMAGE_TAG__GRAFANA=

--- a/baklava.env
+++ b/baklava.env
@@ -88,11 +88,6 @@ EIGENDA_LOCAL_ARCHIVE_BLOBS=${EIGENDA_LOCAL_S3_BUCKET:+0}
 # Set to "true" if you want to launch them, otherwise keep "false"
 MONITORING_ENABLED=false
 
-# GRAFANA_RESTART_POLICY/PROMETHEUS_RESTART_POLICY set the Docker Compose 'restart' policy for Grafana/Prometheus
-# (e.g. 'no', 'always', 'on-failure', or 'unless-stopped')
-GRAFANA_RESTART_POLICY=no
-PROMETHEUS_RESTART_POLICY=no
-
 IMAGE_TAG__HEALTCHECK=
 IMAGE_TAG__PROMETHEUS=
 IMAGE_TAG__GRAFANA=

--- a/baklava.env
+++ b/baklava.env
@@ -84,7 +84,7 @@ EIGENDA_LOCAL_ARCHIVE_BLOBS=${EIGENDA_LOCAL_S3_BUCKET:+0}
 #                                ↓ OPTIONAL ↓                                 #
 ###############################################################################
 
-# MONITORING_ENABLED controls whether Grafana and Prometheus are started
+# MONITORING_ENABLED controls whether Grafana, Prometheus, Influxdb, and Healthcheck are started
 # Set to "true" if you want to launch them, otherwise keep "false"
 MONITORING_ENABLED=false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
   prometheus:
     platform: linux/amd64
     image: prom/prometheus:${IMAGE_TAG__PROMETHEUS:-latest}
-    restart: ${PROMETHEUS_RESTART_POLICY:-no}
+    restart: on-failure
     entrypoint: /scripts/start-prometheus.sh
     env_file:
       - .env
@@ -106,7 +106,7 @@ services:
   grafana:
     platform: linux/amd64
     image: grafana/grafana:${IMAGE_TAG__GRAFANA:-9.3.0}
-    restart: ${GRAFANA_RESTART_POLICY:-no}
+    restart: on-failure
     entrypoint: /scripts/start-grafana.sh
     env_file:
       - ./envs/common/grafana.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,13 @@ services:
   healthcheck:
     platform: linux/amd64
     image: ethereumoptimism/replica-healthcheck:${IMAGE_TAG__HEALTHCHECK:-latest}
-    restart: unless-stopped
+    restart: on-failure
+    entrypoint: /opt/optimism/packages/replica-healthcheck/start-healthcheck.sh
     env_file:
       - ./envs/common/healthcheck.env
       - .env
+    volumes:
+      - ./scripts/start-healthcheck.sh:/opt/optimism/packages/replica-healthcheck/start-healthcheck.sh
     ports:
       - ${PORT__HEALTHCHECK_METRICS:-7300}:7300
 
@@ -121,12 +124,15 @@ services:
   influxdb:
     platform: linux/amd64
     image: influxdb:${IMAGE_TAG__INFLUXDB:-1.8}
-    restart: unless-stopped
+    restart: on-failure
+    entrypoint: /scripts/start-influxdb.sh
     env_file:
       - ./envs/common/influxdb.env
+      - .env
     volumes:
       - ./docker/influxdb/influx_init.iql:/docker-entrypoint-initdb.d/influx_init.iql
       - influxdb_data:/var/lib/influxdb
+      - ./scripts/start-influxdb.sh:/scripts/start-influxdb.sh
     ports:
       - ${PORT__INFLUXDB:-8086}:8086
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,7 @@ services:
     entrypoint: /scripts/start-grafana.sh
     env_file:
       - ./envs/common/grafana.env
+      - .env
     volumes:
       - ./docker/grafana/provisioning/:/etc/grafana/provisioning/:ro
       - ./docker/grafana/dashboards/simple_node_dashboard.json:/var/lib/grafana/dashboards/simple_node_dashboard.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,25 +92,29 @@ services:
   prometheus:
     platform: linux/amd64
     image: prom/prometheus:${IMAGE_TAG__PROMETHEUS:-latest}
-    restart: unless-stopped
+    restart: ${PROMETHEUS_RESTART_POLICY:-no}
+    entrypoint: /scripts/start-prometheus.sh
     env_file:
       - .env
     volumes:
       - ./docker/prometheus:/etc/prometheus
       - prometheus_data:/prometheus
+      - ./scripts/start-prometheus.sh:/scripts/start-prometheus.sh
     ports:
       - ${PORT__PROMETHEUS:-9090}:9090
 
   grafana:
     platform: linux/amd64
     image: grafana/grafana:${IMAGE_TAG__GRAFANA:-9.3.0}
-    restart: unless-stopped
+    restart: ${GRAFANA_RESTART_POLICY:-no}
+    entrypoint: /scripts/start-grafana.sh
     env_file:
       - ./envs/common/grafana.env
     volumes:
       - ./docker/grafana/provisioning/:/etc/grafana/provisioning/:ro
       - ./docker/grafana/dashboards/simple_node_dashboard.json:/var/lib/grafana/dashboards/simple_node_dashboard.json
       - grafana_data:/var/lib/grafana
+      - ./scripts/start-grafana.sh:/scripts/start-grafana.sh
     ports:
       - ${PORT__GRAFANA:-3000}:3000
 

--- a/scripts/start-grafana.sh
+++ b/scripts/start-grafana.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$MONITORING_ENABLED" = "true" ]; then
+  exec /run.sh
+else
+  echo "Grafana is disabled, exiting..."
+  exit 0
+fi

--- a/scripts/start-healthcheck.sh
+++ b/scripts/start-healthcheck.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$MONITORING_ENABLED" = "true" ]; then
+  npm run start
+else
+  echo "Healthcheck is disabled, exiting..."
+  exit 0
+fi

--- a/scripts/start-historical-rpc-node.sh
+++ b/scripts/start-historical-rpc-node.sh
@@ -16,14 +16,19 @@ if [ -z "${HISTORICAL_RPC_DATADIR_PATH}" ]; then
   exit
 fi
 
+METRICS_ARGS="--metrics"
+if [ "$MONITORING_ENABLED" = "true" ]; then
+  METRICS_ARGS="$METRICS_ARGS \
+    --metrics.influxdb \
+    --metrics.influxdb.endpoint=http://influxdb:8086 \
+    --metrics.influxdb.database=historical-rpc-node"
+fi
+
 # Start historical-rpc-node.
 exec geth \
   --$NETWORK_NAME \
   --datadir=$DATADIR \
   --gcmode=archive \
   --syncmode=full \
-  --metrics \
-  --metrics.influxdb \
-  --metrics.influxdb.endpoint=http://influxdb:8086 \
-  --metrics.influxdb.database=historical-rpc-node \
+  $METRICS_ARGS \
   $@

--- a/scripts/start-influxdb.sh
+++ b/scripts/start-influxdb.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$MONITORING_ENABLED" = "true" ]; then
+  /entrypoint.sh influxd
+else
+  echo "Influxdb is disabled, exiting..."
+  exit 0
+fi

--- a/scripts/start-op-geth.sh
+++ b/scripts/start-op-geth.sh
@@ -32,6 +32,14 @@ if [ -z "$OP_GETH__SYNCMODE" ]; then
   fi
 fi
 
+METRICS_ARGS="--metrics"
+if [ "$MONITORING_ENABLED" = "true" ]; then
+  METRICS_ARGS="$METRICS_ARGS \
+    --metrics.influxdb \
+    --metrics.influxdb.endpoint=http://influxdb:8086 \
+    --metrics.influxdb.database=opgeth"
+fi
+
 # Start op-geth.
 exec geth \
   --datadir="$BEDROCK_DATADIR" \
@@ -46,10 +54,7 @@ exec geth \
   --ws.port=8546 \
   --ws.origins="*" \
   --ws.api=debug,eth,txpool,net,engine,web3 \
-  --metrics \
-  --metrics.influxdb \
-  --metrics.influxdb.endpoint=http://influxdb:8086 \
-  --metrics.influxdb.database=opgeth \
+  $METRICS_ARGS \
   --syncmode="$OP_GETH__SYNCMODE" \
   --gcmode="$NODE_TYPE" \
   --authrpc.vhosts="*" \

--- a/scripts/start-prometheus.sh
+++ b/scripts/start-prometheus.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$MONITORING_ENABLED" = "true" ]; then
+  exec /bin/prometheus \
+    --config.file=/etc/prometheus/prometheus.yml \
+    --storage.tsdb.path=/prometheus
+else
+  echo "Prometheus is disabled, exiting..."
+  exit 0
+fi


### PR DESCRIPTION
Closes https://github.com/celo-org/celo-blockchain-planning/issues/919

This PR introduces a mechanism to conditionally start Grafana and Prometheus using environment variables. By default (`MONITORING_ENABLED=false`), neither service is started. If you set `MONITORING_ENABLED=true`, both Grafana and Prometheus will be launched by docker compose up.
