### PR TITLE
Fix wrong deleteDatasources configurations in Grafana datasource setting file

### DIFF
--- a/docker/grafana/provisioning/datasources/all.yml
+++ b/docker/grafana/provisioning/datasources/all.yml
@@ -2,7 +2,8 @@ apiVersion: 1
 
 deleteDatasources:
 - name: 'Prometheus'
-- name: 'InfluxDB'
+- name: 'InfluxDB (historical-rpc-node)'
+- name: 'InfluxDB (op-geth)'
 
 datasources:
 - access: 'proxy'


### PR DESCRIPTION
This PR fixes an issue where the data sources `historical-rpc-node` and `op-geth` are not reset when Grafana container starts. According to configuration in `docker/grafana/provisioning/datasources/all.yml`, all data sources should be reset upon Grafana startup to ensure the settings remain up to date. However, `historical-rpc-node` and `op-geth` were not reset because different names were specified in `deleteDatasources`. This PR corrects `deleteDatasources` setting.

With current [main](8f1c21b6070f75b2d997bfb960f19ef9df8984e1) branch, the logs indicate that the data sources `InfluxDB (historical-rpc-node)` and `InfluxDB (op-geth)` are not deleted, while the `Prometheus` data source is deleted and recreated after Grafana starts.

```bash
# docker compose logs grafana

...
grafana-1  | logger=infra.usagestats.collector t=2025-03-10T06:44:22.496972008Z level=info msg="registering usage stat providers" usageStatsProvidersLen=2
grafana-1  | logger=provisioning.datasources t=2025-03-10T06:44:22.514643383Z level=info msg="deleted correlations based on configuration" ds_name=Prometheus
grafana-1  | logger=provisioning.datasources t=2025-03-10T06:44:22.514671716Z level=info msg="deleted datasource based on configuration" name=Prometheus
grafana-1  | logger=provisioning.datasources t=2025-03-10T06:44:22.515441799Z level=info msg="inserting datasource from configuration " name=Prometheus uid=6R74VAnVz
...
```

With this fix, you will see that all data sources are removed and recreated.

```bash
# docker compose logs grafana

...
grafana-1  | logger=provisioning.datasources t=2025-03-10T06:46:04.999536889Z level=info msg="deleted correlations based on configuration" ds_name=Prometheus
grafana-1  | logger=provisioning.datasources t=2025-03-10T06:46:04.999568014Z level=info msg="deleted datasource based on configuration" name=Prometheus
grafana-1  | logger=provisioning.datasources t=2025-03-10T06:46:05.003639305Z level=info msg="deleted correlations based on configuration" ds_name="InfluxDB (historical-rpc-node)"
grafana-1  | logger=provisioning.datasources t=2025-03-10T06:46:05.003671139Z level=info msg="deleted datasource based on configuration" name="InfluxDB (historical-rpc-node)"
grafana-1  | logger=provisioning.datasources t=2025-03-10T06:46:05.006763389Z level=info msg="deleted correlations based on configuration" ds_name="InfluxDB (op-geth)"
grafana-1  | logger=provisioning.datasources t=2025-03-10T06:46:05.00678543Z level=info msg="deleted datasource based on configuration" name="InfluxDB (op-geth)"
grafana-1  | logger=provisioning.datasources t=2025-03-10T06:46:05.007029555Z level=info msg="inserting datasource from configuration " name=Prometheus uid=6R74VAnVz
grafana-1  | logger=provisioning.datasources t=2025-03-10T06:46:05.034076472Z level=info msg="inserting datasource from configuration " name="InfluxDB (historical-rpc-node)" uid=4knV40nVz
grafana-1  | logger=provisioning.datasources t=2025-03-10T06:46:05.050555014Z level=info msg="inserting datasource from configuration " name="InfluxDB (op-geth)" uid=4knV40nVb
...
```

Basically, this issue is not critical, but I couldn't start Grafana in my environment due to a conflict with the data source UID. However, this issue didn't occur after resetting docker volumes.
