### PR TITLE
Bring baklava.env in line with alfajores.env

### DIFF
--- a/baklava.env
+++ b/baklava.env
@@ -22,7 +22,7 @@ OP_NODE__L1_BEACON=https://ethereum-holesky-beacon-api.publicnode.com
 OP_NODE__RPC_TYPE=basic
 
 # Reference L2 node to run healthcheck against
-HEALTHCHECK__REFERENCE_RPC_PROVIDER=https://baklava-forno.baklava.celo-testnet.org
+HEALTHCHECK__REFERENCE_RPC_PROVIDER=https://baklava-forno.celo-testnet.org
 
 ###############################################################################
 #                            ↓ OPTIONAL (BEDROCK) ↓                           #
@@ -36,7 +36,7 @@ HISTORICAL_RPC_DATADIR_PATH=
 # Optional provider to serve RPC requests requiring historical state, if set op-geth will proxy
 # requests requiring state prior to the L2 start to here. If set this overrides the use of a local L1
 # node via HISTORICAL_RPC_DATADIR_PATH.
-OP_GETH__HISTORICAL_RPC=https://baklava-forno.celo-testnet.org
+OP_GETH__HISTORICAL_RPC=
 
 # Set to "full" to force op-geth to use --syncmode=full
 OP_GETH__SYNCMODE=


### PR DESCRIPTION
Use the shorter baklava forno URL for the healthcheck provider and don't use forno as the historical RPC node.