### PR TITLE
Update config docs for historical rpc node

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ We recommend one of the 3 following configurations for your L2 node. For more de
   - `erigon` - Erigon
   - `basic` - Other providers
 - **HEALTHCHECK__REFERENCE_RPC_PROVIDER** - Specify the public healthcheck RPC endpoint for the Layer 2 network.
-- **HISTORICAL_RPC_DATADIR_PATH** - Datadir path to use for legacy archive node to serve pre-L2 historical state.
-- **OP_GETH__HISTORICAL_RPC** - RPC Endpoint for fetching pre-L2 historical state. If set, this overrides the **HISTORICAL_RPC_DATADIR_PATH** setting.
+- **HISTORICAL_RPC_DATADIR_PATH** - Datadir path to use for legacy archive node to serve pre-L2 historical state. If set a Celo L1 node will be run in archive mode to serve requests requiring state for blocks prior to the L2 hardfork and op-geth will be configured to proxy those requests to the Celo L1 node.
+- **OP_GETH__HISTORICAL_RPC** - RPC Endpoint for fetching pre-L2 historical state, if set op-geth will proxy requests requiring state prior to the L2 hardfork to here. If set this overrides the use of a local Celo L1 node via **HISTORICAL_RPC_DATADIR_PATH** so no local Celo L1 node will be run.
 - **IMAGE_TAG**[...]__ - Use custom docker image for specified components.
 - **PORT**[...]__ - Use custom port for specified components.
 

--- a/alfajores.env
+++ b/alfajores.env
@@ -29,12 +29,12 @@ HEALTHCHECK__REFERENCE_RPC_PROVIDER=https://alfajores-forno.celo-testnet.org
 ###############################################################################
 
 # Optional path to a datadir for an L1 node to serve RPC requests requiring historical states. If
-# set an L1 node will be run in archive mode to serve requests requiring state for blocks prior to the
-# L2 hardfork and op-geth will be configured to proxy those requests to the L1 node.
+# set a Celo L1 node will be run in archive mode to serve requests requiring state for blocks prior to the
+# L2 hardfork and op-geth will be configured to proxy those requests to the Celo L1 node.
 HISTORICAL_RPC_DATADIR_PATH=
 
 # Optional provider to serve RPC requests requiring historical state, if set op-geth will proxy
-# requests requiring state prior to the L2 start to here. If set this overrides the use of a local L1
+# requests requiring state prior to the L2 start to here. If set this overrides the use of a local Celo L1
 # node via HISTORICAL_RPC_DATADIR_PATH.
 OP_GETH__HISTORICAL_RPC=
 

--- a/baklava.env
+++ b/baklava.env
@@ -29,12 +29,12 @@ HEALTHCHECK__REFERENCE_RPC_PROVIDER=https://baklava-forno.baklava.celo-testnet.o
 ###############################################################################
 
 # Optional path to a datadir for an L1 node to serve RPC requests requiring historical states. If
-# set an L1 node will be run in archive mode to serve requests requiring state for blocks prior to the
-# L2 hardfork and op-geth will be configured to proxy those requests to the L1 node.
+# set a Celo L1 node will be run in archive mode to serve requests requiring state for blocks prior to the
+# L2 hardfork and op-geth will be configured to proxy those requests to the Celo L1 node.
 HISTORICAL_RPC_DATADIR_PATH=
 
 # Optional provider to serve RPC requests requiring historical state, if set op-geth will proxy
-# requests requiring state prior to the L2 start to here. If set this overrides the use of a local L1
+# requests requiring state prior to the L2 start to here. If set this overrides the use of a local Celo L1
 # node via HISTORICAL_RPC_DATADIR_PATH.
 OP_GETH__HISTORICAL_RPC=https://baklava-forno.celo-testnet.org
 


### PR DESCRIPTION
We had feedback from a validator that the documentation for the
historical rpc node did not make it clear that it was optional.

Fixes https://github.com/celo-org/celo-blockchain-planning/issues/918