### PR TITLE
fix: change op-node p2p port in docker-compose.yml to default port and fix peering issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,8 +83,8 @@ services:
       - ./scripts/:/scripts
       - shared:/shared
     ports:
-      - ${PORT__OP_NODE_P2P:-9003}:9003/udp
-      - ${PORT__OP_NODE_P2P:-9003}:9003/tcp
+      - ${PORT__OP_NODE_P2P:-9222}:9222/udp
+      - ${PORT__OP_NODE_P2P:-9222}:9222/tcp
       - ${PORT__OP_NODE_HTTP:-9545}:9545
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
The default op-node p2p port should be `9222`, not `9003`. The default p2p port can be found in the optimism docs [here](https://docs.optimism.io/operators/node-operators/configuration/consensus-config#p2plistentcp). 

This port change should help fix the op-node peering issues. 

Thanks to @zviadm for pointing this out on the @celo-org validator discord channel! 

**Notes**
Another Optimism docs page ([Node base configuration](https://docs.optimism.io/operators/node-operators/configuration/base-config)) also mentions the wrong port. This issue has been addressed [here](https://github.com/ethereum-optimism/docs/pull/1546). 

