### PR TITLE
Update docker-compose.yml op-geth to 2.0.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   op-geth:
     platform: linux/amd64
-    image: us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/op-geth:celo-v2.0.0
+    image: us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/op-geth:celo-v2.0.4
     restart: on-failure
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-geth.sh


### PR DESCRIPTION
Update op-geth - This is a bugfix release which is recommended for all RPC providers. https://github.com/celo-org/op-geth/releases/tag/celo-v2.0.4