### PR TITLE
Use restart on failure for eigenda proxy

### DIFF
--- a/alfajores.env
+++ b/alfajores.env
@@ -85,9 +85,6 @@ OP_NODE__P2P_ADVERTISE_IP=
 # Specifies the endpoint of the eigenda proxy to use. If this is unset then a local eigenda proxy will be used.
 EIGENDA_PROXY_ENDPOINT=
 
-# Set to 0 if EIGENDA_PROXY_ENDPOINT is defined otherwise empty. This shouldn't be set manually.
-USE_LOCAL_EIGENDA_PROXY_IF_UNSET=${EIGENDA_PROXY_ENDPOINT:+0}
-
 EIGENDA_LOCAL_DISPERSER_RPC=disperser-holesky.eigenda.xyz:443 
 EIGENDA_LOCAL_SVC_MANAGER_ADDR=0xD4A7E1Bd8015057293f0D0A557088c286942e84b
 

--- a/baklava.env
+++ b/baklava.env
@@ -85,9 +85,6 @@ OP_NODE__P2P_ADVERTISE_IP=
 # Specifies the endpoint of the eigenda proxy to use. If this is unset then a local eigenda proxy will be used.
 EIGENDA_PROXY_ENDPOINT=
 
-# Set to 0 if EIGENDA_PROXY_ENDPOINT is defined otherwise empty. This shouldn't be set manually.
-USE_LOCAL_EIGENDA_PROXY_IF_UNSET=${EIGENDA_PROXY_ENDPOINT:+0}
-
 EIGENDA_LOCAL_DISPERSER_RPC=disperser-holesky.eigenda.xyz:443 
 EIGENDA_LOCAL_SVC_MANAGER_ADDR=0xD4A7E1Bd8015057293f0D0A557088c286942e84b
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
   eigenda-proxy:
     platform: linux/amd64
     image: ghcr.io/layr-labs/eigenda-proxy:v1.6.4
-    restart: unless-stopped
+    restart: on-failure
     stop_grace_period: 5m
     entrypoint: /scripts/start-eigenda-proxy.sh
     env_file:
@@ -42,10 +42,6 @@ services:
       - ${PORT_EIGENDA_PROXY:-4242}:4242
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    deploy:
-      # If USE_LOCAL_EIGENDA_PROXY_IF_UNSET is unset or empty, then we set replicas to 1,
-      # otherwise use the value of USE_LOCAL_EIGENDA_PROXY_IF_UNSET which should be 0.
-      replicas: ${USE_LOCAL_EIGENDA_PROXY_IF_UNSET:-1}
 
   op-geth:
     platform: linux/amd64

--- a/mainnet.env
+++ b/mainnet.env
@@ -85,9 +85,6 @@ OP_NODE__P2P_ADVERTISE_IP=
 # Specifies the endpoint of the eigenda proxy to use. If this is unset then a local eigenda proxy will be used.
 EIGENDA_PROXY_ENDPOINT=
 
-# Set to 0 if EIGENDA_PROXY_ENDPOINT is defined otherwise empty. This shouldn't be set manually.
-USE_LOCAL_EIGENDA_PROXY_IF_UNSET=${EIGENDA_PROXY_ENDPOINT:+0}
-
 EIGENDA_LOCAL_DISPERSER_RPC=disperser.eigenda.xyz:443 
 EIGENDA_LOCAL_SVC_MANAGER_ADDR=0x870679e138bcdf293b7ff14dd44b70fc97e12fc0
 

--- a/scripts/start-eigenda-proxy.sh
+++ b/scripts/start-eigenda-proxy.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+if [ -n "$EIGENDA_PROXY_ENDPOINT" ]; then
+  echo "Not starting local EigenDA proxy since proxy endpoint ($EIGENDA_PROXY_ENDPOINT) is defined"
+  exit
+fi
+
 # Archive blobs configuration
 if [ -n "$EIGENDA_LOCAL_ARCHIVE_BLOBS" ]; then
   export EXTENDED_EIGENDA_PARAMETERS="${EXTENDED_EIGENDA_PARAMETERS:-} --s3.credential-type=$EIGENDA_LOCAL_S3_CREDENTIAL_TYPE \

--- a/scripts/start-op-node.sh
+++ b/scripts/start-op-node.sh
@@ -17,7 +17,7 @@ fi
 
 # OP_NODE_ALTDA_DA_SERVER is picked up by the op-node binary.
 export OP_NODE_ALTDA_DA_SERVER=$EIGENDA_PROXY_ENDPOINT
-if [ -n $USE_LOCAL_EIGENDA_PROXY_IF_UNSET ]; then
+if [ -z $OP_NODE_ALTDA_DA_SERVER ]; then
   OP_NODE_ALTDA_DA_SERVER="http://eigenda-proxy:4242"
 fi
 


### PR DESCRIPTION
This brings the approach to conditional running of
eigenda-proxy in line with all the other services.

Fixes https://github.com/celo-org/celo-blockchain-planning/issues/858