### PR TITLE
Explicitly set p2p peerstore path

### DIFF
--- a/scripts/start-op-node.sh
+++ b/scripts/start-op-node.sh
@@ -36,4 +36,5 @@ exec op-node \
   --metrics.port=7300 \
   --syncmode=execution-layer \
   --p2p.priv.path=/shared/op-node_p2p_priv.txt \
+  --p2p.peerstore.path=/shared/opnode_peerstore_db \
   $EXTENDED_ARG $@


### PR DESCRIPTION
The [default value path is "opnode_peerstore_db"](https://docs.optimism.io/operators/node-operators/configuration/consensus-config#p2ppeerstorepath). We ensure it is persisted by storing the db on the mounted docker volume path.

Improves peer recovery after a restart.