### PR TITLE
Add --txpool.nolocals flag to op-geth

### DIFF
--- a/scripts/start-op-geth.sh
+++ b/scripts/start-op-geth.sh
@@ -73,5 +73,6 @@ exec geth \
   --snapshot=true \
   --verbosity=3 \
   --history.transactions=0 \
+  --txpool.nolocals \
   $EXTENDED_ARG $@
 


### PR DESCRIPTION
Not having the flag resulted in unexecutable transactions building up in the node.