### PR TITLE
Set AltDA server as cmdflag

### DIFF
--- a/scripts/start-op-node.sh
+++ b/scripts/start-op-node.sh
@@ -37,4 +37,5 @@ exec op-node \
   --syncmode=execution-layer \
   --p2p.priv.path=/shared/op-node_p2p_priv.txt \
   --p2p.peerstore.path=/shared/opnode_peerstore_db \
+  --altda.da-server=$OP_NODE_ALTDA_DA_SERVER \
   $EXTENDED_ARG $@


### PR DESCRIPTION
Set the url for the AltDA Server as command flag, as it's required for arguments set from entrypoint script.