### PR TITLE
chore: change default challenger image tag to `v1`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,9 +90,7 @@ services:
 
   challenger:
     platform: linux/amd64
-    # TODO: once a stable version is released,
-    # add automatic "v{major}" tagging to the CI and reference "v1" here as default tag
-    image: us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/op-succinct-challenger:${IMAGE_TAG__CHALLENGER:-1.0.0-rc.6}
+    image: us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/op-succinct-challenger:${IMAGE_TAG__CHALLENGER:-v1}
     restart: on-failure
     stop_grace_period: 5m
     entrypoint: /scripts/start-challenger.sh


### PR DESCRIPTION
Now that the `1.0.0` version is released, we can set the default image tag to `v1` - so that it always tracks the latest backwards compatible version.