### PR TITLE
Update rollup.json for Jovian

### DIFF
--- a/envs/celo-sepolia/config/rollup.json
+++ b/envs/celo-sepolia/config/rollup.json
@@ -15,7 +15,9 @@
       "scalar": "0x0100000000000000000000000000000000000000000000000000000000000000",
       "gasLimit": 60000000,
       "eip1559Params": "0x0000000000000000",
-      "operatorFeeParams": "0x0000000000000000000000000000000000000000000000000000000000000000"
+      "operatorFeeParams": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "minBaseFee": 0,
+      "daFootprintGasScalar": 0
     }
   },
   "block_time": 1,
@@ -33,6 +35,7 @@
   "granite_time": 0,
   "holocene_time": 0,
   "isthmus_time": 0,
+  "jovian_time": 1773749037,
   "batch_inbox_address": "0x00076c1f80cdb1d670046465c5ccd04e9e78c1f0",
   "deposit_contract_address": "0x44ae3d41a335a7d05eb533029917aad35662dcc2",
   "l1_system_config_address": "0x760a5f022c9940f4a074e0030be682f560d29818",

--- a/envs/mainnet/config/rollup.json
+++ b/envs/mainnet/config/rollup.json
@@ -14,7 +14,10 @@
       "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "scalar": "0x0100000000000000000000000000000000000000000000000000000000000000",
       "gasLimit": 30000000,
-      "eip1559Params": "0x0000000000000000"
+      "eip1559Params": "0x0000000000000000",
+      "operatorFeeParams": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "minBaseFee": 0,
+      "daFootprintGasScalar": 0
     }
   },
   "block_time": 1,
@@ -30,6 +33,10 @@
   "ecotone_time": 0,
   "fjord_time": 0,
   "granite_time": 0,
+  "holocene_time": 1752073200,
+  "isthmus_time": 1752073200,
+  "pectra_blob_schedule_time": 1752073200,
+  "jovian_time": 1774958788,
   "batch_inbox_address": "0xff00000000000000000000000000000000042220",
   "deposit_contract_address": "0xc5c5d157928bdbd2acf6d0777626b6c75a9eaedc",
   "l1_system_config_address": "0x89e31965d844a309231b1f17759ccaf1b7c09861",

--- a/scripts/start-op-node.sh
+++ b/scripts/start-op-node.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ -n "${IS_CUSTOM_CHAIN}" ]; then
-  export EXTENDED_ARG="${EXTENDED_ARG:-} --rollup.config=/chainconfig/rollup.json"
+  export EXTENDED_ARG="${EXTENDED_ARG:-} --rollup.config=/chainconfig/rollup.json --rollup.load-protocol-versions=true"
   if [ ! -f /chainconfig/rollup.json ]; then
     echo "Missing rollup.json file: Either update the repo to pull the published rollup.json or migrate your Celo L1 datadir to generate rollup.json."
     exit


### PR DESCRIPTION
Updated rollup.json of Celo Sepolia and Celo Mainnet for Jovian readiness. Since we removed the overrides in op-node and op-geth, need to add those missing hardfork times for Mainnet.

I verified that the Celo Sepolia rollup config matches with the one from using network flag.

We may want to change the way to load the rollup config from using rollup.json to using superchain-registry for Mainnet release.