### PR TITLE
Add celo-reth as alternative execution client

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,24 @@ And the "Succinct Challenger" dashboard (available at Dashboards > Browse > Succ
 
 ---
 
+## Using celo-reth as Execution Client
+
+You can use [celo-reth](https://github.com/celo-org/celo-reth) as an alternative execution client instead of op-geth. This uses a Docker Compose override file that disables op-geth and adds a celo-reth service in its place.
+
+```sh
+IMAGE_TAG__CELO_RETH=your-image:tag docker compose -f docker-compose.yml -f docker-compose.celo-reth.yml up -d --build
+```
+
+Or set `IMAGE_TAG__CELO_RETH` in your `.env` file and run:
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.celo-reth.yml up -d --build
+```
+
+All other configuration (`.env` variables, monitoring, challenger, etc.) works the same as with op-geth.
+
+---
+
 ## L1 Data Migration
 
 > 💡 Most users should use snap sync (default) and skip this section. Migration is only needed for specific use cases requiring full historical verification or archive functionality.

--- a/celo-sepolia.env
+++ b/celo-sepolia.env
@@ -121,6 +121,7 @@ IMAGE_TAG__INFLUXDB=
 IMAGE_TAG__OP_GETH=
 IMAGE_TAG__OP_NODE=
 IMAGE_TAG__CHALLENGER=
+# IMAGE_TAG__CELO_RETH=  # Required when using docker-compose.celo-reth.yml override
 
 # Exposed server ports (must be unique)
 # See docker-compose.yml for default values

--- a/docker-compose.celo-reth.yml
+++ b/docker-compose.celo-reth.yml
@@ -1,0 +1,19 @@
+services:
+  op-geth:
+    image: ${IMAGE_TAG__CELO_RETH:?IMAGE_TAG__CELO_RETH is required}
+    # pull_policy: never  # Uncomment for local images
+    # platform: ""        # Uncomment to clear linux/amd64 for local images
+    entrypoint: /scripts/start-celo-reth.sh
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8545'"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+    ports:
+      - "9200:9200/udp"
+
+  op-node:
+    depends_on:
+      op-geth:
+        condition: service_healthy

--- a/mainnet.env
+++ b/mainnet.env
@@ -131,6 +131,7 @@ IMAGE_TAG__INFLUXDB=
 IMAGE_TAG__OP_GETH=
 IMAGE_TAG__OP_NODE=
 IMAGE_TAG__CHALLENGER=
+# IMAGE_TAG__CELO_RETH=  # Required when using docker-compose.celo-reth.yml override
 
 # Exposed server ports (must be unique)
 # See docker-compose.yml for default values

--- a/scripts/start-celo-reth.sh
+++ b/scripts/start-celo-reth.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+set -e
+
+# Create JWT if it doesn't exist
+if [ ! -f "/shared/jwt.txt" ]; then
+  echo "Creating JWT..."
+  mkdir -p /shared
+  openssl rand -hex 32 > /shared/jwt.txt
+fi
+
+# Determine the chain spec: use genesis.json for custom chains, otherwise built-in "celo"
+if [ -n "${IS_CUSTOM_CHAIN}" ] && [ -f /chainconfig/genesis.json ]; then
+  CHAIN_ARG="--chain=/chainconfig/genesis.json"
+else
+  CHAIN_ARG="--chain=celo"
+fi
+
+# Check if either OP_GETH__HISTORICAL_RPC or HISTORICAL_RPC_DATADIR_PATH is set and if so set the historical rpc option.
+if [ -n "$OP_GETH__HISTORICAL_RPC" ] || [ -n "$HISTORICAL_RPC_DATADIR_PATH" ] ; then
+  export EXTENDED_ARG="${EXTENDED_ARG:-} --rollup.historicalrpc=${OP_GETH__HISTORICAL_RPC:-http://historical-rpc-node:8545}"
+fi
+
+if [ -n "$IPC_PATH" ]; then
+  export EXTENDED_ARG="${EXTENDED_ARG:-} --ipcpath=$IPC_PATH"
+fi
+
+# Init the datadir if it's a custom chain and the datadir is empty
+if [ -n "${IS_CUSTOM_CHAIN}" ] && [ -z "$(ls -A "$BEDROCK_DATADIR")" ]; then
+  echo "Initializing custom chain genesis..."
+  if [ ! -f /chainconfig/genesis.json ]; then
+    echo "Missing genesis.json file: Either update the repo to pull the published genesis.json or migrate your Celo L1 datadir to generate genesis.json."
+    exit 1
+  fi
+  celo-reth init $CHAIN_ARG --datadir="$BEDROCK_DATADIR"
+fi
+
+# In reth, --full enables pruning for a non-archive node.
+# Without --full, reth keeps all historical state (archive mode).
+FULL_ARG=""
+if [ "$NODE_TYPE" = "full" ]; then
+  FULL_ARG="--full"
+fi
+
+METRICS_ARGS="--metrics=0.0.0.0:9001"
+
+# Start celo-reth.
+exec celo-reth node \
+  $CHAIN_ARG \
+  --datadir="$BEDROCK_DATADIR" \
+  $FULL_ARG \
+  --http \
+  --http.corsdomain="*" \
+  --http.addr=0.0.0.0 \
+  --http.port=8545 \
+  --http.api=web3,debug,eth,txpool,net \
+  --ws \
+  --ws.addr=0.0.0.0 \
+  --ws.port=8546 \
+  --ws.origins="*" \
+  --ws.api=debug,eth,txpool,net,web3 \
+  $METRICS_ARGS \
+  --authrpc.addr=0.0.0.0 \
+  --authrpc.port=8551 \
+  --authrpc.jwtsecret=/shared/jwt.txt \
+  --rollup.sequencer="$BEDROCK_SEQUENCER_HTTP" \
+  --rollup.disable-tx-pool-gossip \
+  --bootnodes="$GETH_BOOTNODES" \
+  --port="${PORT__OP_GETH_P2P:-30303}" \
+  --nat="$OP_GETH__NAT" \
+  --txpool.nolocals \
+  -vvv \
+  $EXTENDED_ARG "$@"


### PR DESCRIPTION
Add Docker Compose override and startup script to run celo-reth instead of op-geth, with documentation and env file placeholders.