### PR TITLE
Upgrade op-geth to celo-v2.2.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   op-geth:
     platform: linux/amd64
-    image: us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/op-geth:celo-v2.2.1
+    image: us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/op-geth:celo-v2.2.2
     restart: on-failure
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-geth.sh


### PR DESCRIPTION
This release increases the default log index from ~1 month to ~1 year.

Users wishing to use a different time can set number of blocks to retain a log index by setting `--history.logs` to some number of blocks.