### PR TITLE
op-node: Add `--verifier.l1-confs=4` flag

### DIFF
--- a/scripts/start-op-node.sh
+++ b/scripts/start-op-node.sh
@@ -35,6 +35,7 @@ exec op-node \
   --metrics.addr=0.0.0.0 \
   --metrics.port=7300 \
   --syncmode=execution-layer \
+  --verifier.l1-confs=4 \
   --p2p.priv.path=/shared/op-node_p2p_priv.txt \
   --p2p.peerstore.path=/shared/opnode_peerstore_db \
   $EXTENDED_ARG $@


### PR DESCRIPTION
Keeps the verifier 4 L1 blocks behind the L1 head before deriving L2 data, providing tolerance for shallow L1 reorgs.