### PR TITLE
Wait for op-reth engine before starting op-node

### DIFF
--- a/scripts/start-op-node.sh
+++ b/scripts/start-op-node.sh
@@ -21,6 +21,19 @@ if [ -z "$OP_NODE_ALTDA_DA_SERVER" ]; then
   OP_NODE_ALTDA_DA_SERVER="http://eigenda-proxy:4242"
 fi
 
+# Wait for the op-reth engine API before starting op-node. op-reth only binds
+# port 8551 once `celo-reth node` is running, which is after any OP_RETH__SNAPSHOT
+# download/import finishes (can take a long time on mainnet or a slow link).
+# Without this, op-node exits after its ~10 internal connection retries and
+# crash-loops until op-reth is ready. No timeout here on purpose: op-node waits
+# as long as the snapshot takes and then starts, so the node always comes up on
+# its own without operator intervention.
+echo "Waiting for op-reth engine API (op-reth:8551)..."
+while ! nc -z -w 3 op-reth 8551 2>/dev/null; do
+  sleep 5
+done
+echo "op-reth engine is reachable; starting op-node."
+
 # Start op-node.
 exec op-node \
   --l1=$OP_NODE__RPC_ENDPOINT \


### PR DESCRIPTION
## What

Make `start-op-node.sh` wait until the op-reth engine API (`op-reth:8551`) is reachable before launching op-node.

## Why

op-node retries the L2 engine RPC only about 10 times (~70s) at startup and then exits. With `OP_RETH__SNAPSHOT=true`, op-reth spends a long time downloading and importing the snapshot before its engine API comes up, so op-node crash-loops for the whole bootstrap, recovering only via `restart: on-failure`. It works but floods the logs.

## How

The start script blocks on a `nc -z op-reth 8551` loop before launching op-node. There is no timeout on purpose: op-node waits as long as the snapshot takes and then starts, so the node always comes up on its own with no operator intervention and no crash-loop noise.

An earlier revision used an op-reth `healthcheck` plus `depends_on: condition: service_healthy`. I moved away from that because any bounded healthcheck (`start_period` or finite `retries`) has a ceiling: if op-reth is not healthy by then it goes `unhealthy`, `docker compose up` aborts op-node, and op-node will not start until the operator re-runs `up`. A near-infinite `retries` avoids the ceiling but makes `docker compose up -d` block for the entire snapshot. The wait loop has neither problem.

## Verified

Brought the stack up with docker compose (without snapshot): op-node waited until op-reth started up. Zero engine-dial crash-loop entries.

op-node logs:
```log
Waiting for op-reth engine API (op-reth:8551)...
op-reth engine is reachable; starting op-node.
t=2026-06-23T13:02:07+0000 lvl=warn msg="Unknown env var" prefix=OP_NODE env_var="OP_NODE__RPC_ENDPOINT=https://proxyd.sepolia.cel2.celo-networks-dev.org/?apikey=69a921736b1a9abcda36d138f39d919c3478d969e770e09e1d614ba7e720a4f4"
...
t=2026-06-23T13:02:07+0000 lvl=info msg="Initializing rollup node" version=v0.0.0-a590fbdc-2026-03-16T18:58:52Z
```