### PR TITLE
Add opt-in historical-proofs support

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,13 +2,13 @@
 
 > ⚠️ Migrated datadirs are in geth format and cannot be used with op-reth, the execution client used by this setup. Run your node with an empty `DATADIR_PATH` instead; pre-L2 history is served via the historical-rpc-node service or `OP_RETH__HISTORICAL_RPC`. The instructions below are kept for reference.
 >
-> For detailed migration instructions, refer to the [official migration guide](https://docs.celo.org/cel2/operators/migrate-node).
+> For detailed migration instructions, refer to the [official migration guide](https://docs.celo.org/infra-partners/operators/migrate-node).
 
 If you need to migrate existing Celo L1 data to L2, you have two options:
 
 ## Option 1: Download Pre-Migrated Data
 
-Download migrated datadirs from the official sources listed in the [Celo Docs](https://docs.celo.org/cel2/operators/migrate-node).
+Download migrated datadirs from the official sources listed in the [Celo Docs](https://docs.celo.org/infra-partners/operators/migrate-node).
 
 ## Option 2: Migrate Your Own Data
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ cd celo-l2-node-docker-compose
 - **OP_RETH__HISTORICAL_RPC** - RPC Endpoint for fetching pre-L2 historical state. If set, op-reth will proxy requests requiring state prior to the L2 hardfork there. If set, this overrides the use of a local Celo L1 node via **HISTORICAL_RPC_DATADIR_PATH**, which means that no local Celo L1 node will be run.
 - **DATADIR_PATH** - Use a custom datadir instead of the default at `./envs/<network>/datadir`. Must be empty on first start; datadirs written by op-geth cannot be reused.
 - **OP_RETH__SNAPSHOT** - When `true`, bootstrap an empty datadir from a published snapshot (`snapshots.celo.org`) instead of syncing from scratch. The tier downloaded is set by `NODE_TYPE`. Skipped once the datadir already contains data.
+- **OP_RETH__PROOFS_HISTORY_ENABLED** - Set to `true` to serve deep `eth_getProof` within a bounded window from a sidecar DB, avoiding reth's slow, OOM-prone historical reverts (see [Historical proofs](#historical-proofs)). Off by default.
+- **OP_RETH__PROOFS_HISTORY_WINDOW** - Number of recent blocks to keep proofs for. Defaults to `1296000` (~15 days at 1s blocks).
+- **PROOFS_HISTORY_DATADIR_PATH** - Where the proofs-history database is stored. Keep it on a separate volume from the chaindata datadir. Defaults to `./envs/<network>/proofs`.
 - **IMAGE_TAG[...]__** - Use a custom Docker image for specified components.
 - **MONITORING_ENABLED** - Enables the following services when set to `true`: `healthcheck`, `prometheus`, `grafana`, `influxdb`.
 
@@ -129,6 +132,51 @@ Approximate sizes (compressed download / extracted on disk):
 | minimal | ~7 GB / ~20 GB | ~65 GB / ~130 GB |
 | full | ~11 GB / ~30 GB | ~215 GB / ~355 GB |
 | archive | ~13 GB / ~50 GB | ~390 GB / ~1.35 TB |
+
+### Historical proofs
+
+Serving `eth_getProof` for an older block normally forces reth to rebuild that
+block's state by reverting diffs backward from the chain tip, which is slow at
+depth and can OOM-crash the node, even on an archive node. Historical proofs add
+a bounded-window sidecar that answers deep `eth_getProof` from precomputed,
+versioned trie nodes instead: fast and crash-free, for about the last 15 days by
+default. It is an opt-in op-reth sidecar, off by default. Enable it in your
+`.env`:
+
+```text
+OP_RETH__PROOFS_HISTORY_ENABLED=true
+```
+
+When enabled, op-reth initializes the proofs storage **once**, before it starts
+following the chain, by anchoring it at the datadir's current head. It then
+fills proofs forward up to `OP_RETH__PROOFS_HISTORY_WINDOW` blocks. Proofs are
+recorded forward only: the window grows from the anchor onward and cannot be
+backfilled to earlier blocks.
+
+> ⚠️ The proofs storage must be anchored on a datadir that has synced past its
+> genesis block. Anchoring at genesis wedges the node with repeated
+> `StateRootMismatch` errors, so startup refuses it: if the datadir is still at
+> genesis, op-reth skips initialization, logs a warning, and starts without
+> proofs.
+
+This leaves three cases:
+
+- **Bootstrapped from a snapshot (`OP_RETH__SNAPSHOT=true`, the default):** the
+  datadir is already synced, so proofs are initialized automatically on the
+  first start.
+- **An existing synced datadir:** point `DATADIR_PATH` at it and enable proofs;
+  the storage is initialized on the next start.
+- **Syncing from scratch (`OP_RETH__SNAPSHOT=false`):** the first start has
+  nothing to anchor, so proofs are skipped with a warning and op-reth syncs
+  without them. Once it has synced, restart (`docker compose up -d`) to
+  initialize proofs against the synced datadir.
+
+The proofs database lives on a separate volume (`PROOFS_HISTORY_DATADIR_PATH`,
+default `./envs/<network>/proofs`). It is sized by the window (not the node
+tier) and can use significant disk, so plan capacity accordingly.
+
+See the [historical proofs operator guide](https://docs.celo.org/infra-partners/operators/historical-proofs)
+for window sizing, querying, and verification details.
 
 ### P2P Networking Environment Variables
 
@@ -262,7 +310,7 @@ In order to ensure the ability to fully derive the L2 state from consensus L1 da
 
 ## Installation and Configuration
 
-Refer to the [previous instructions](#installation-and-configuration) and the [Celo Docs](https://docs.celo.org/cel2/operators/run-node) on how to run a node and configure it as an archive node.
+Refer to the [previous instructions](#installation-and-configuration) and the [Celo Docs](https://docs.celo.org/infra-partners/operators/run-node) on how to run a node and configure it as an archive node.
 
 ### Required steps
 

--- a/celo-sepolia.env
+++ b/celo-sepolia.env
@@ -44,6 +44,25 @@ DATADIR_PATH=./envs/${NETWORK_NAME}/datadir
 # the datadir already holds data, so it is safe to leave enabled across restarts.
 OP_RETH__SNAPSHOT=true
 
+# Historical proofs serve deep eth_getProof within a bounded window from a
+# sidecar DB, avoiding the slow, OOM-prone historical-state reverts reth
+# otherwise does (useful on any node type, archive included). Disabled by
+# default. When enabled, op-reth initializes the proofs storage once (before it
+# starts following the chain) against the datadir's synced head, so the datadir
+# must already be synced past genesis. Enable it on a node bootstrapped from a
+# snapshot or already synced. On a node syncing from scratch, let op-reth sync
+# first, then enable this and restart.
+OP_RETH__PROOFS_HISTORY_ENABLED=false
+
+# How many recent blocks to keep proofs for. Default ~1,296,000 (about 15 days
+# at 1s blocks). Larger windows need more disk; the proofs DB is sized by the
+# window and can be large, so plan capacity.
+OP_RETH__PROOFS_HISTORY_WINDOW=1296000
+
+# Where the proofs-history database lives. Keep it on a separate volume from the
+# chaindata datadir.
+PROOFS_HISTORY_DATADIR_PATH=./envs/${NETWORK_NAME}/proofs
+
 # Controls how op-reth determines its public IP that is shared via the
 # discovery mechanism. The value should be one of
 # (any|none|upnp|publicip|extip:<IP>|stun:<IP:PORT>) if any is selected

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       - ./scripts/:/scripts
       - shared:/shared
       - ${DATADIR_PATH}:/reth
+      - ${PROOFS_HISTORY_DATADIR_PATH:-./proofs}:/proofs
     ports:
       - ${PORT__OP_RETH_HTTP:-9993}:8545
       - ${PORT__OP_RETH_WS:-9994}:8546

--- a/mainnet.env
+++ b/mainnet.env
@@ -54,6 +54,25 @@ DATADIR_PATH=./envs/${NETWORK_NAME}/datadir
 # the datadir already holds data, so it is safe to leave enabled across restarts.
 OP_RETH__SNAPSHOT=true
 
+# Historical proofs serve deep eth_getProof within a bounded window from a
+# sidecar DB, avoiding the slow, OOM-prone historical-state reverts reth
+# otherwise does (useful on any node type, archive included). Disabled by
+# default. When enabled, op-reth initializes the proofs storage once (before it
+# starts following the chain) against the datadir's synced head, so the datadir
+# must already be synced past genesis. Enable it on a node bootstrapped from a
+# snapshot or already synced. On a node syncing from scratch, let op-reth sync
+# first, then enable this and restart.
+OP_RETH__PROOFS_HISTORY_ENABLED=false
+
+# How many recent blocks to keep proofs for. Default ~1,296,000 (about 15 days
+# at 1s blocks). Larger windows need more disk; the proofs DB is sized by the
+# window and can be large, so plan capacity.
+OP_RETH__PROOFS_HISTORY_WINDOW=1296000
+
+# Where the proofs-history database lives. Keep it on a separate volume from the
+# chaindata datadir.
+PROOFS_HISTORY_DATADIR_PATH=./envs/${NETWORK_NAME}/proofs
+
 # Controls how op-reth determines its public IP that is shared via the
 # discovery mechanism. The value should be one of
 # (any|none|upnp|publicip|extip:<IP>|stun:<IP:PORT>) if any is selected

--- a/scripts/start-op-reth.sh
+++ b/scripts/start-op-reth.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# In-container paths. docker-compose bind-mounts the host DATADIR_PATH and
+# PROOFS_HISTORY_DATADIR_PATH onto these.
+DATADIR=/reth
+PROOFS_STORAGE_PATH=/proofs
+
 # Create JWT if it doesn't exist or is empty. Uses od because the op-reth
 # image doesn't ship xxd; op-reth fails to start on an empty JWT file.
 if [ ! -s "/shared/jwt.txt" ]; then
@@ -11,7 +16,7 @@ fi
 
 # Refuse to start on an op-geth datadir. op-reth stores its data in MDBX
 # format and cannot read geth chaindata.
-if [ -d "/reth/geth" ]; then
+if [ -d "$DATADIR/geth" ]; then
   echo "The directory at DATADIR_PATH contains op-geth data, which op-reth cannot use."
   echo "Point DATADIR_PATH at an empty directory to sync from scratch."
   exit 1
@@ -21,13 +26,13 @@ fi
 # scratch. On by default (OP_RETH__SNAPSHOT=true); set it to false to sync from
 # genesis. Skipped once /reth already holds data. celo-reth selects the
 # snapshots.celo.org manifest for --chain automatically (celo-sepolia / mainnet).
-if [ "$OP_RETH__SNAPSHOT" = "true" ] && [ ! -d "/reth/db" ]; then
+if [ "$OP_RETH__SNAPSHOT" = "true" ] && [ ! -d "$DATADIR/db" ]; then
   # NODE_TYPE doubles as the snapshot tier, matching celo-reth's download
   # presets: minimal | full | archive. Defaults to full.
   # ponytail: no validation of the value — celo-reth rejects a bad --<tier>.
   SNAPSHOT_PRESET="--${NODE_TYPE:-full}"
-  echo "No data in /reth; downloading ${SNAPSHOT_PRESET} snapshot for ${OP_RETH__CHAIN}..."
-  celo-reth download --datadir=/reth --chain="$OP_RETH__CHAIN" "$SNAPSHOT_PRESET"
+  echo "No data in $DATADIR; downloading ${SNAPSHOT_PRESET} snapshot for ${OP_RETH__CHAIN}..."
+  celo-reth download --datadir="$DATADIR" --chain="$OP_RETH__CHAIN" "$SNAPSHOT_PRESET"
 fi
 
 # Check if either OP_RETH__HISTORICAL_RPC or HISTORICAL_RPC_DATADIR_PATH is set and if so set the historical rpc option.
@@ -46,12 +51,53 @@ if [ "$NODE_TYPE" != "archive" ]; then
   export EXTENDED_ARG="${EXTENDED_ARG:-} --${NODE_TYPE:-full}"
 fi
 
+# Historical proofs (deep eth_getProof within a bounded window). When enabled,
+# initialize the proofs storage against the datadir before starting the node,
+# then run with --proofs-history. The storage must be anchored on a datadir
+# synced past genesis: anchoring at genesis wedges the node with repeated
+# StateRootMismatch errors (the packed trie is only materialized once the node
+# executes blocks).
+#
+# The synced head lives in static files, not the MDBX CanonicalHeaders table, so
+# read it from the Headers static-file block range that `db stats` reports (e.g.
+# "0..=28493895"). The range start is the genesis block (0 on Sepolia, the L2
+# migration block on Mainnet) and the end is the head; head > genesis means
+# synced past genesis. (The static-file *filenames* use fixed 500k ranges and
+# overshoot the real head, so we read the range `db stats` gets from each file's
+# header instead.) It fails closed (skip, run without proofs) so an un-synced
+# node never anchors proofs at genesis.
+if [ "$OP_RETH__PROOFS_HISTORY_ENABLED" = "true" ]; then
+  PROOFS_READY=false
+  RANGE="$(celo-reth db --datadir="$DATADIR" --chain="$OP_RETH__CHAIN" stats 2>/dev/null |
+    grep -E '^\|[[:space:]]*Headers[[:space:]]*\|[[:space:]]*[0-9]+\.\.=[0-9]+' |
+    grep -oE '[0-9]+\.\.=[0-9]+' | head -1 || true)"
+  GENESIS_BLOCK="$(printf '%s' "$RANGE" | grep -oE '[0-9]+' | head -1)"
+  HEAD_BLOCK="$(printf '%s' "$RANGE" | grep -oE '[0-9]+' | tail -1)"
+  if [ -n "$HEAD_BLOCK" ] && [ -n "$GENESIS_BLOCK" ] && [ "$HEAD_BLOCK" -gt "$GENESIS_BLOCK" ]; then
+    # proofs init is idempotent: it no-ops when the storage already has its
+    # anchor, so restarts do not re-backfill.
+    echo "Datadir synced past genesis (head ${HEAD_BLOCK} > genesis ${GENESIS_BLOCK}); ensuring proofs history is initialized (idempotent)..."
+    if celo-reth proofs init --datadir="$DATADIR" --chain="$OP_RETH__CHAIN" --proofs-history.storage-path="$PROOFS_STORAGE_PATH" --proofs-history.storage-version=v2; then
+      PROOFS_READY=true
+    else
+      echo "ERROR: 'celo-reth proofs init' failed; starting op-reth WITHOUT historical proofs. Investigate and restart to retry."
+    fi
+  else
+    echo "WARNING: op-reth datadir is not synced past genesis yet (head=${HEAD_BLOCK:-unknown}); skipping proofs history."
+    echo "WARNING: op-reth will start without it. Once it has synced, restart to initialize and enable proofs."
+  fi
+  if [ "$PROOFS_READY" = "true" ]; then
+    export EXTENDED_ARG="${EXTENDED_ARG:-} --proofs-history --proofs-history.storage-path=$PROOFS_STORAGE_PATH --proofs-history.storage-version=v2 --proofs-history.window=${OP_RETH__PROOFS_HISTORY_WINDOW:-1296000}"
+    echo "Historical proofs enabled (storage=$PROOFS_STORAGE_PATH, window=${OP_RETH__PROOFS_HISTORY_WINDOW:-1296000}); starting op-reth..."
+  fi
+fi
+
 # Operators forwarding logs to an aggregator can switch to structured output
 # by adding --log.stdout.format=json to the command below.
 # Start op-reth.
 exec celo-reth node \
   --chain="$OP_RETH__CHAIN" \
-  --datadir=/reth \
+  --datadir="$DATADIR" \
   --storage.v2=true \
   --http \
   --http.corsdomain="*" \


### PR DESCRIPTION
Adds opt-in historical-proofs support so a node can serve deep `eth_getProof` within a bounded window from the op-reth proofs-history sidecar, without running a full archive node. Off by default, gated behind `OP_RETH__PROOFS_HISTORY_ENABLED`. Part of celo-org/celo-blockchain-planning#1396.

## What it does

`start-op-reth.sh` runs `celo-reth proofs init` before starting the node, then runs op-reth with `--proofs-history`. The proofs storage must be anchored on a datadir synced past genesis (anchoring at genesis wedges the node with repeated `StateRootMismatch` errors), so the script reads the synced head from the `Headers` static-file block range reported by `celo-reth db stats` and only initializes, and adds the `--proofs-history` flags, when the head is past genesis. It fails closed: an un-synced node starts without proofs and just syncs. This covers a snapshot bootstrap (auto), an existing synced datadir (auto), and syncing from scratch (initialized on the next restart once synced). The proofs DB lives on a separate volume and the window defaults to ~15 days at 1s blocks.

New `.env` variables (both networks): `OP_RETH__PROOFS_HISTORY_ENABLED` (default `false`), `OP_RETH__PROOFS_HISTORY_WINDOW` (default `1296000`), `PROOFS_HISTORY_DATADIR_PATH` (default `./envs/<network>/proofs`). The README gains a "Historical proofs" section (a dedicated operator guide is a companion PR in celo-org/docs), and its `docs.celo.org` links are updated to the current `infra-partners/operators/*` paths.

## Verified

The end-to-end behavior is verified. A node bootstrapping from a snapshot and then running `proofs init` was confirmed to anchor at the correct synced head on celo-sepolia. The proofs DB forward-fill (the ExEx filling the window as the chain advances) is verified live on a GKE pod.