### PR TITLE
Update reth to v1.0.0.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   op-reth:
     platform: linux/amd64
-    image: ${IMAGE_REPO__OP_RETH:-us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/op-reth}:${IMAGE_TAG__OP_RETH:-celo-v1.0.0-rc.1}
+    image: ${IMAGE_REPO__OP_RETH:-us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/op-reth}:${IMAGE_TAG__OP_RETH:-celo-v1.0.0}
     restart: on-failure
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-reth.sh


### PR DESCRIPTION
The new image is available at https://console.cloud.google.com/artifacts/tags/devopsre/us-west1/celo-blockchain-public/op-reth/celo-v1.0.0 .